### PR TITLE
Downgrade required Java to version 11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ dependencies {
 group = 'com.datadoghq'
 version = '0.1.1-SNAPSHOT'
 
-sourceCompatibility = '12'
-targetCompatibility = '12'
+sourceCompatibility = '11'
+targetCompatibility = '11'
 
 task sourcesJar(type: Jar) {
     archiveClassifier = 'sources'


### PR DESCRIPTION
### What does this PR do?

Fixes #7 by changing build time Java version requirement from 12 to 11.

### Motivation

Using Java 11

### Additional Notes

The code itself seems to work under Java 9 and later (though its technically EOL), however it was unclear if there were future constraints requiring a specific Java version.
