### PR TITLE
Add a cubically interpolated mapping

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
@@ -7,9 +7,9 @@ package com.datadoghq.sketch.ddsketch;
 
 import com.datadoghq.sketch.QuantileSketch;
 import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
+import com.datadoghq.sketch.ddsketch.mapping.CubicallyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.mapping.IndexMapping;
 import com.datadoghq.sketch.ddsketch.mapping.LogarithmicMapping;
-import com.datadoghq.sketch.ddsketch.mapping.QuadraticallyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.store.Bin;
 import com.datadoghq.sketch.ddsketch.store.CollapsingHighestDenseStore;
 import com.datadoghq.sketch.ddsketch.store.CollapsingLowestDenseStore;
@@ -275,7 +275,7 @@ public class DDSketch implements QuantileSketch<DDSketch> {
      */
     public static DDSketch balanced(double relativeAccuracy) {
         return new DDSketch(
-                new QuadraticallyInterpolatedMapping(relativeAccuracy),
+                new CubicallyInterpolatedMapping(relativeAccuracy),
                 UnboundedSizeDenseStore::new
         );
     }
@@ -291,7 +291,7 @@ public class DDSketch implements QuantileSketch<DDSketch> {
      */
     public static DDSketch balancedCollapsingLowest(double relativeAccuracy, int maxNumBins) {
         return new DDSketch(
-                new QuadraticallyInterpolatedMapping(relativeAccuracy),
+                new CubicallyInterpolatedMapping(relativeAccuracy),
                 () -> new CollapsingLowestDenseStore(maxNumBins)
         );
     }
@@ -307,7 +307,7 @@ public class DDSketch implements QuantileSketch<DDSketch> {
      */
     public static DDSketch balancedCollapsingHighest(double relativeAccuracy, int maxNumBins) {
         return new DDSketch(
-                new QuadraticallyInterpolatedMapping(relativeAccuracy),
+                new CubicallyInterpolatedMapping(relativeAccuracy),
                 () -> new CollapsingHighestDenseStore(maxNumBins)
         );
     }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -1,0 +1,84 @@
+package com.datadoghq.sketch.ddsketch.mapping;
+
+import java.util.Objects;
+
+/**
+ * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link LogarithmicMapping}) by
+ * extracting the floor value of the logarithm to the base 2 from the binary representations of floating-point values
+ * and cubically interpolating the logarithm in-between.
+ */
+public class CubicallyInterpolatedMapping implements IndexMapping {
+
+    private static final double A = 6.0 / 35.0;
+    private static final double B = -3.0 / 5.0;
+    private static final double C = 10.0 / 7.0;
+
+    private final double relativeAccuracy;
+    private final double multiplier;
+
+    public CubicallyInterpolatedMapping(double relativeAccuracy) {
+        if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
+            throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
+        }
+        this.relativeAccuracy = relativeAccuracy;
+        this.multiplier = 7.0 / (10.0 * Math.log((1 + relativeAccuracy) / (1 - relativeAccuracy)));
+    }
+
+    @Override
+    public int index(double value) {
+        final long longBits = Double.doubleToRawLongBits(value);
+        final double s = DoubleBitOperationHelper.getSignificandPlusOne(longBits) - 1;
+        final double e = (double) DoubleBitOperationHelper.getExponent(longBits);
+        final double index = (((A * s + B) * s + C) * s + e) * multiplier;
+        return index >= 0 ? (int) index : (int) index - 1;
+    }
+
+    @Override
+    public double value(int index) {
+        final double normalizedIndex = (double) index / multiplier;
+        final long exponent = (long) Math.floor(normalizedIndex);
+        // Derived from Cardano's formula
+        final double d0 = B * B - 3 * A * C;
+        final double d1 = 2 * B * B * B - 9 * A * B * C - 27 * A * A * (normalizedIndex - exponent);
+        final double p = Math.cbrt((d1 - Math.sqrt(d1 * d1 - 4 * d0 * d0 * d0)) / 2);
+        final double significandPlusOne = -(B + p + d0 / p) / (3 * A) + 1;
+        return DoubleBitOperationHelper.buildDouble(exponent, significandPlusOne) * (1 + relativeAccuracy);
+    }
+
+    @Override
+    public double relativeAccuracy() {
+        return relativeAccuracy;
+    }
+
+    @Override
+    public double minIndexableValue() {
+        return Math.max(
+                Math.pow(2, (Integer.MIN_VALUE + 1) / multiplier + 1), // so that index >= Integer.MIN_VALUE
+                Double.MIN_NORMAL * (1 + relativeAccuracy) / (1 - relativeAccuracy)
+        );
+    }
+
+    @Override
+    public double maxIndexableValue() {
+        return Math.min(
+                Math.pow(2, Integer.MAX_VALUE / multiplier - 1), // so that index <= Integer.MAX_VALUE
+                Double.MAX_VALUE / (1 + relativeAccuracy)
+        );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return Double.compare(relativeAccuracy, ((CubicallyInterpolatedMapping) o).relativeAccuracy) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(relativeAccuracy);
+    }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -9,6 +9,9 @@ import java.util.Objects;
  */
 public class CubicallyInterpolatedMapping implements IndexMapping {
 
+    // Assuming we write the index as index(v) = floor(multiplier*ln(2)/ln(gamma)*(e+As^3+Bs^2+Cs)), where v=2^e(1+s)
+    // and gamma = (1+relativeAccuracy)/(1-relativeAccuracy), those are the coefficients that minimize the multiplier,
+    // therefore the memory footprint of the sketch, while ensuring the relative accuracy of the sketch.
     private static final double A = 6.0 / 35.0;
     private static final double B = -3.0 / 5.0;
     private static final double C = 10.0 / 7.0;

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
@@ -31,6 +31,12 @@ package com.datadoghq.sketch.ddsketch.mapping;
  * <td>100% (reference)</td>
  * </tr>
  * <tr>
+ * <td>{@link CubicallyInterpolatedMapping}</td>
+ * <td>~1% ({@code 7/(10*log(2))-1})</td>
+ * <td>~1% ({@code 7/(10*log(2))-1})</td>
+ * <td>~30%</td>
+ * </tr>
+ * <tr>
  * <td>{@link QuadraticallyInterpolatedMapping}</td>
  * <td>~8% ({@code 3/(4*log(2))-1})</td>
  * <td>~8% ({@code 3/(4*log(2))-1})</td>

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
@@ -56,6 +56,11 @@ package com.datadoghq.sketch.ddsketch.mapping;
  * </tr>
  * <caption>Comparison of various implementations of {@code IndexMapping}</caption>
  * </table>
+ * <p>
+ * {@link CubicallyInterpolatedMapping}, which uses a polynomial of degree 3 to approximate the logarithm is a good
+ * compromise as its memory overhead compared to the optimal logarithmic mapping is only 1%, and it is about 3 times
+ * faster than the logarithmic mapping. Using a polynomial of higher degree would not yield a significant gain in memory
+ * efficiency (less than 1%), while it would degrade its insertion speed to some extent.
  */
 public interface IndexMapping {
 

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMappingTest.java
@@ -1,0 +1,9 @@
+package com.datadoghq.sketch.ddsketch.mapping;
+
+public class CubicallyInterpolatedMappingTest extends IndexMappingTest {
+
+    @Override
+    IndexMapping getMapping(double relativeAccuracy) {
+        return new CubicallyInterpolatedMapping(relativeAccuracy);
+    }
+}


### PR DESCRIPTION
This PR adds a mapping that computes the bucket index that a value belongs to using the exponent and the significand of its floating-point value representation, applying a polynomial of degree 3 to the latter. This follows the same idea as `LinearlyInterpolatedMapping` and `QuadraticallyInterpolatedMapping`, which respectively use polynomials of degrees 1 and 2, and goes one step (or degree, as it happens) further.

Calculating the bucket index with this mapping is much faster than computing the logarithm of the value (by a factor of 3 according to some benchmarks I ran, although it depends on various factors), and this mapping incurs a memory usage overhead of only 1% compared to the memory-optimal logarithmic mapping, under the relative accuracy condition. In comparison, the overheads for `LinearlyInterpolatedMapping` and `QuadraticallyInterpolatedMapping` are respectively 44% and 8%.

## Methodology / sketch of the proof

Here are a few words about how I calculated the optimal polynomial coefficients.

The idea is that the exponent of the floating-point representation gives the floor value of the logarithm to base 2 of the input value for free. However, we want the logarithm to base _γ_=(1+_α_)/(1-_α_), where _α_ is the relative accuracy of the sketch. We can of course deduce that from the logarithm to the base 2, but that requires more than the floor value to base 2, and we need to actually approximate the logarithm between successive powers of 2. A way to do that relatively cheaply is to use the significand and to compute operations that are cheap for the CPU such as additions and multiplications. Therefore, writing ![image](https://user-images.githubusercontent.com/10637860/79134416-fa471c80-7dad-11ea-8d83-c4785030dc1a.png), where _e_ is an integer and _s_ is between 0 (included) and 1 (excluded), we compute the index as (the floor value of) ![image](https://user-images.githubusercontent.com/10637860/79135499-accbaf00-7daf-11ea-9b8a-ae37e04b6d86.png), where _P_ is a polynomial (of degree 3 here) and _m_ is a multiplier (≥1) that corrects for the fact that the polynomial does not geometrically pull apart values from one another as well as the logarithm.

It's clear that we want that multiplier to be as low as possible, because the higher _m_, the smaller the buckets and the more buckets we need to cover the same range of values (hence the larger sketch memory size). But we still need the buckets to be small enough so that values that are distinct by a multiplying factor equal to _γ_ don't end up in the same bucket (otherwise, the sketch can't be _α_-accurate). That is, we want ![image](https://user-images.githubusercontent.com/10637860/79136999-34b2b880-7db2-11ea-835e-ac5a38e0e24c.png), for any _α_ and its corresponding _γ_ (≤1 would work as well). Writing ![image](https://user-images.githubusercontent.com/10637860/79137846-c2db6e80-7db3-11ea-808d-3921b281f09d.png), we can show that that condition amounts to _f_ increasing and ![image](https://user-images.githubusercontent.com/10637860/79138154-52811d00-7db4-11ea-8432-12eb6bc6451c.png) where _f_ is differentiable (that's not necessarily the case at powers of 2). Therefore, to achieve the best sketch memory efficiency, we need to maximize the infimum of ![image](https://user-images.githubusercontent.com/10637860/79138402-bdcaef00-7db4-11ea-9324-f72d18ddcb74.png).

Given that ![image](https://user-images.githubusercontent.com/10637860/79152776-160deb00-7dcd-11ea-8235-f99b63ca3f7e.png), we know that ![image](https://user-images.githubusercontent.com/10637860/79152944-5b321d00-7dcd-11ea-8777-0960eccadc88.png), and it is enough to study ![image](https://user-images.githubusercontent.com/10637860/79153011-77ce5500-7dcd-11ea-80c5-81cd76d0a743.png) between 1 and ln(2), that is, with ![image](https://user-images.githubusercontent.com/10637860/79155676-c847b180-7dd1-11ea-9466-52a2eba4dbfd.png), for _e_ equal to 0 and _s_ between 0 and 1. In other words, we want to find _P_ that maximizes ![image](https://user-images.githubusercontent.com/10637860/79155566-96cee600-7dd1-11ea-8760-bc41b859b1b4.png), which is equal to ![image](https://user-images.githubusercontent.com/10637860/79140810-d9d08f80-7db8-11ea-8983-c708cea87ce3.png).

_f_ is increasing and, it doesn't have discontinuity points (that would be an underefficient mapping), therefore we can require _P_(0)=0 and _P_(1)=1. Hence, we can write ![image](https://user-images.githubusercontent.com/10637860/79140285-07690900-7db8-11ea-8bde-d5e2dba8251c.png) and we end up with only two coefficients (_u_, _v_) to optimize. To find the coefficients that maximize the infimum, we can study the variations of ![image](https://user-images.githubusercontent.com/10637860/79196903-2a83cf00-7e31-11ea-8898-b4747d952291.png), which is a polynomial of degree 3, depending of values of _u_ and _v_. That part is a bit tedious, but eventually we show that the infimum is maximized if _u_ and _v_ are such that the infimum is equal to _Q_(0) and _Q_(_r_), where _r_ is one of the critical point (local minimum) of _Q_, distinct from 0. That gives a quadratic equation in the two variables _u_ and _v_, and given that _Q_(0)=1+_u_, we take the solution that maximizes _u_. Finally, we get _u_=3/7 and _v_=-6/35, or alternatively, `A`, `B` and `C` as in the code if we write ![image](https://user-images.githubusercontent.com/10637860/79156684-9c2d3000-7dd3-11ea-94b8-cce07ea61298.png). You can convince yourself that those are the optimal coefficients by moving the red point on [that graph](https://www.desmos.com/calculator/zqcpw4454k).

With those values, we can choose _m_ as small as 7/(10 ln(2)), which is about 1.01, hence the memory usage overhead of 1%. For the reverse mapping (getting the value back from the index), implemented as the `value` method, we need to solve a cubic equation, which we can implement by copying [formulas from Wikipedia](https://en.wikipedia.org/wiki/Cubic_equation#General_cubic_formula).