### PR TITLE
Fix integer overflow when handling large values

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingDenseStore.java
@@ -23,7 +23,7 @@ abstract class CollapsingDenseStore extends DenseStore {
     }
 
     @Override
-    int getNewLength(int desiredLength) {
-        return Math.min(super.getNewLength(desiredLength), maxNumBins);
+    long getNewLength(int newMinIndex, int newMaxIndex) {
+        return Math.min(super.getNewLength(newMinIndex, newMaxIndex), maxNumBins);
     }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStore.java
@@ -37,7 +37,7 @@ public class CollapsingHighestDenseStore extends CollapsingDenseStore {
     @Override
     void adjust(int newMinIndex, int newMaxIndex) {
 
-        if (newMaxIndex - newMinIndex + 1 > counts.length) {
+        if ((long) newMaxIndex - newMinIndex + 1 > counts.length) {
 
             // The range of indices is too wide, buckets of lowest indices need to be collapsed.
 
@@ -116,7 +116,12 @@ public class CollapsingHighestDenseStore extends CollapsingDenseStore {
         for (; index > maxIndex && index >= store.minIndex; index--) {
             counts[counts.length - 1] += store.counts[index - store.offset];
         }
-        for (; index >= store.minIndex; index--) {
+        for (; index > store.minIndex; index--) {
+            counts[index - offset] += store.counts[index - store.offset];
+        }
+        // This is a separate test so that the comparison in the previous loop is strict (>) and handles
+        // store.minIndex = Integer.MIN_VALUE.
+        if (index == store.minIndex) {
             counts[index - offset] += store.counts[index - store.offset];
         }
     }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStore.java
@@ -37,7 +37,7 @@ public class CollapsingLowestDenseStore extends CollapsingDenseStore {
     @Override
     void adjust(int newMinIndex, int newMaxIndex) {
 
-        if (newMaxIndex - newMinIndex + 1 > counts.length) {
+        if ((long) newMaxIndex - newMinIndex + 1 > counts.length) {
 
             // The range of indices is too wide, buckets of lowest indices need to be collapsed.
 
@@ -115,7 +115,12 @@ public class CollapsingLowestDenseStore extends CollapsingDenseStore {
         for (; index < minIndex && index <= store.maxIndex; index++) {
             counts[0] += store.counts[index - store.offset];
         }
-        for (; index <= store.maxIndex; index++) {
+        for (; index < store.maxIndex; index++) {
+            counts[index - offset] += store.counts[index - store.offset];
+        }
+        // This is a separate test so that the comparison in the previous loop is strict (<) and handles
+        // store.maxIndex = Integer.MAX_VALUE.
+        if (index == store.maxIndex) {
             counts[index - offset] += store.counts[index - store.offset];
         }
     }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStoreTest.java
@@ -29,7 +29,7 @@ abstract class CollapsingHighestDenseStoreTest extends StoreTest {
         if (!minIndex.isPresent()) {
             return Collections.emptyMap();
         }
-        final int maxStorableIndex = minIndex.getAsInt() + maxNumBins() - 1;
+        final int maxStorableIndex = (int) Math.min(Integer.MAX_VALUE, (long) minIndex.getAsInt() + maxNumBins() - 1);
         return Arrays.stream(bins)
             .collect(Collectors.groupingBy(
                 bin -> Math.min(bin.getIndex(), maxStorableIndex),

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStoreTest.java
@@ -29,7 +29,7 @@ abstract class CollapsingLowestDenseStoreTest extends StoreTest {
         if (!maxIndex.isPresent()) {
             return Collections.emptyMap();
         }
-        final int minStorableIndex = maxIndex.getAsInt() - maxNumBins() + 1;
+        final int minStorableIndex = (int) Math.max(Integer.MIN_VALUE, (long) maxIndex.getAsInt() - maxNumBins() + 1);
         return Arrays.stream(bins)
             .collect(Collectors.groupingBy(
                 bin -> Math.max(bin.getIndex(), minStorableIndex),

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -186,6 +186,16 @@ abstract class StoreTest {
     }
 
     @Test
+    void testExtremeValues() {
+        testAdding(Integer.MIN_VALUE);
+        testAdding(Integer.MAX_VALUE);
+        testAdding(0, Integer.MIN_VALUE);
+        testAdding(0, Integer.MAX_VALUE);
+        testAdding(Integer.MIN_VALUE, Integer.MAX_VALUE);
+        testAdding(Integer.MAX_VALUE, Integer.MIN_VALUE);
+    }
+
+    @Test
     void testMergingEmpty() {
         testMerging(new int[]{}, new int[]{});
         testMerging(new int[]{}, new int[]{ 0 });
@@ -204,6 +214,20 @@ abstract class StoreTest {
     void testMergingConstant() {
         testMerging(new int[]{ 2, 2 }, new int[]{ 2, 2, 2 }, new int[]{ 2 });
         testMerging(new int[]{ -8, -8 }, new int[]{}, new int[]{ -8 });
+    }
+
+    @Test
+    void testMergingExtremeValues() {
+        testMerging(new int[]{ 0 }, new int[]{ Integer.MIN_VALUE });
+        testMerging(new int[]{ 0 }, new int[]{ Integer.MAX_VALUE });
+        testMerging(new int[]{ Integer.MIN_VALUE }, new int[]{ 0 });
+        testMerging(new int[]{ Integer.MAX_VALUE }, new int[]{ 0 });
+        testMerging(new int[]{ Integer.MIN_VALUE }, new int[]{ Integer.MIN_VALUE });
+        testMerging(new int[]{ Integer.MAX_VALUE }, new int[]{ Integer.MAX_VALUE });
+        testMerging(new int[]{ Integer.MIN_VALUE }, new int[]{ Integer.MAX_VALUE });
+        testMerging(new int[]{ Integer.MAX_VALUE }, new int[]{ Integer.MIN_VALUE });
+        testMerging(new int[]{ 0 }, new int[]{ Integer.MIN_VALUE, Integer.MAX_VALUE });
+        testMerging(new int[]{ Integer.MIN_VALUE, Integer.MAX_VALUE }, new int[]{ 0 });
     }
 
     @Test

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -59,6 +59,18 @@ abstract class StoreTest {
             assertThrows(NoSuchElementException.class, store::getMaxIndex);
         } else {
             assertFalse(store.isEmpty());
+            final int expectedMinIndex = expectedCounts.entrySet().stream()
+                    .filter(entry -> entry.getValue() != 0)
+                    .mapToInt(Entry::getKey)
+                    .min()
+                    .getAsInt();
+            assertEquals(expectedMinIndex, store.getMinIndex());
+            final int expectedMaxIndex = expectedCounts.entrySet().stream()
+                    .filter(entry -> entry.getValue() != 0)
+                    .mapToInt(Entry::getKey)
+                    .max()
+                    .getAsInt();
+            assertEquals(expectedMaxIndex, store.getMaxIndex());
         }
         assertSameCounts(expectedCounts, getCounts(store.getStream()));
         assertSameCounts(expectedCounts, getCounts(store.getAscendingStream()));

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/UnboundedSizeDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/UnboundedSizeDenseStoreTest.java
@@ -11,4 +11,16 @@ class UnboundedSizeDenseStoreTest extends ExhaustiveStoreTest {
     Store newStore() {
         return new UnboundedSizeDenseStore();
     }
+
+    @Override
+    void testExtremeValues() {
+        // UnboundedSizeDenseStore is not meant to be used with values that are extremely far from one another as it
+        // would allocate an excessively large array.
+    }
+
+    @Override
+    void testMergingExtremeValues() {
+        // UnboundedSizeDenseStore is not meant to be used with values that are extremely far from one another as it
+        // would allocate an excessively large array.
+    }
 }


### PR DESCRIPTION
Make sure `CollapsingLowestDenseStore` and `CollapsingHighestDenseStore` can handle any input values between `Integer.MIN_VALUE` and `Integer.MAX_VALUE`, including extreme ones.