### PR TITLE
Allow log-like mappings to return offset indexes

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -1,13 +1,11 @@
 package com.datadoghq.sketch.ddsketch.mapping;
 
-import java.util.Objects;
-
 /**
  * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link LogarithmicMapping}) by
  * extracting the floor value of the logarithm to the base 2 from the binary representations of floating-point values
  * and cubically interpolating the logarithm in-between.
  */
-public class CubicallyInterpolatedMapping implements IndexMapping {
+public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
 
     // Assuming we write the index as index(v) = floor(multiplier*ln(2)/ln(gamma)*(e+As^3+Bs^2+Cs)), where v=2^e(1+s)
     // and gamma = (1+relativeAccuracy)/(1-relativeAccuracy), those are the coefficients that minimize the multiplier,
@@ -16,72 +14,36 @@ public class CubicallyInterpolatedMapping implements IndexMapping {
     private static final double B = -3.0 / 5.0;
     private static final double C = 10.0 / 7.0;
 
-    private final double relativeAccuracy;
-    private final double multiplier;
-
     public CubicallyInterpolatedMapping(double relativeAccuracy) {
-        if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
-            throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
-        }
-        this.relativeAccuracy = relativeAccuracy;
-        this.multiplier = 7.0 / (10.0 * Math.log((1 + relativeAccuracy) / (1 - relativeAccuracy)));
+        super(relativeAccuracy);
     }
 
     @Override
-    public int index(double value) {
+    double log(double value) {
         final long longBits = Double.doubleToRawLongBits(value);
         final double s = DoubleBitOperationHelper.getSignificandPlusOne(longBits) - 1;
         final double e = (double) DoubleBitOperationHelper.getExponent(longBits);
-        final double index = (((A * s + B) * s + C) * s + e) * multiplier;
-        return index >= 0 ? (int) index : (int) index - 1;
+        return ((A * s + B) * s + C) * s + e;
     }
 
     @Override
-    public double value(int index) {
-        final double normalizedIndex = (double) index / multiplier;
-        final long exponent = (long) Math.floor(normalizedIndex);
+    double logInverse(double index) {
+        final long exponent = (long) Math.floor(index);
         // Derived from Cardano's formula
         final double d0 = B * B - 3 * A * C;
-        final double d1 = 2 * B * B * B - 9 * A * B * C - 27 * A * A * (normalizedIndex - exponent);
+        final double d1 = 2 * B * B * B - 9 * A * B * C - 27 * A * A * (index - exponent);
         final double p = Math.cbrt((d1 - Math.sqrt(d1 * d1 - 4 * d0 * d0 * d0)) / 2);
         final double significandPlusOne = -(B + p + d0 / p) / (3 * A) + 1;
-        return DoubleBitOperationHelper.buildDouble(exponent, significandPlusOne) * (1 + relativeAccuracy);
+        return DoubleBitOperationHelper.buildDouble(exponent, significandPlusOne);
     }
 
     @Override
-    public double relativeAccuracy() {
-        return relativeAccuracy;
+    double base() {
+        return 2;
     }
 
     @Override
-    public double minIndexableValue() {
-        return Math.max(
-                Math.pow(2, (Integer.MIN_VALUE + 1) / multiplier + 1), // so that index >= Integer.MIN_VALUE
-                Double.MIN_NORMAL * (1 + relativeAccuracy) / (1 - relativeAccuracy)
-        );
-    }
-
-    @Override
-    public double maxIndexableValue() {
-        return Math.min(
-                Math.pow(2, Integer.MAX_VALUE / multiplier - 1), // so that index <= Integer.MAX_VALUE
-                Double.MAX_VALUE / (1 + relativeAccuracy)
-        );
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        return Double.compare(relativeAccuracy, ((CubicallyInterpolatedMapping) o).relativeAccuracy) == 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(relativeAccuracy);
+    double correctingFactor() {
+        return 7 / (10 * Math.log(2));
     }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -18,6 +18,13 @@ public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
         super(relativeAccuracy);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    CubicallyInterpolatedMapping(double gamma, double indexOffset) {
+        super(gamma, indexOffset);
+    }
+
     @Override
     double log(double value) {
         final long longBits = Double.doubleToRawLongBits(value);

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
@@ -5,78 +5,38 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
-import java.util.Objects;
-
 /**
  * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link LogarithmicMapping}) by
  * extracting the floor value of the logarithm to the base 2 from the binary representations of floating-point values
  * and linearly interpolating the logarithm in-between.
  */
-public class LinearlyInterpolatedMapping implements IndexMapping {
-
-    private final double relativeAccuracy;
-    private final double multiplier;
+public class LinearlyInterpolatedMapping extends LogLikeIndexMapping {
 
     public LinearlyInterpolatedMapping(double relativeAccuracy) {
-        if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
-            throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
-        }
-        this.relativeAccuracy = relativeAccuracy;
-        this.multiplier = 1 / Math.log((1 + relativeAccuracy) / (1 - relativeAccuracy));
+        super(relativeAccuracy);
     }
 
     @Override
-    public int index(double value) {
+    double log(double value) {
         final long longBits = Double.doubleToRawLongBits(value);
-        final double index = multiplier * (
-            (double) DoubleBitOperationHelper.getExponent(longBits)
-                + DoubleBitOperationHelper.getSignificandPlusOne(longBits)
-        );
-        return index >= 0 ? (int) index : (int) index - 1;
+        return (double) DoubleBitOperationHelper.getExponent(longBits)
+            + DoubleBitOperationHelper.getSignificandPlusOne(longBits);
     }
 
     @Override
-    public double value(int index) {
-        final double normalizedIndex = (double) index / multiplier;
-        final long exponent = (long) Math.floor(normalizedIndex - 1);
-        final double significandPlusOne = normalizedIndex - exponent;
-        return DoubleBitOperationHelper.buildDouble(exponent, significandPlusOne) * (1 + relativeAccuracy);
+    double logInverse(double index) {
+        final long exponent = (long) Math.floor(index - 1);
+        final double significandPlusOne = index - exponent;
+        return DoubleBitOperationHelper.buildDouble(exponent, significandPlusOne);
     }
 
     @Override
-    public double relativeAccuracy() {
-        return relativeAccuracy;
+    double base() {
+        return 2;
     }
 
     @Override
-    public double minIndexableValue() {
-        return Math.max(
-            Math.pow(2, (Integer.MIN_VALUE + 1) / multiplier), // so that index >= Integer.MIN_VALUE
-            Double.MIN_NORMAL * (1 + relativeAccuracy) / (1 - relativeAccuracy)
-        );
-    }
-
-    @Override
-    public double maxIndexableValue() {
-        return Math.min(
-            Math.pow(2, Integer.MAX_VALUE / multiplier - 1), // so that index <= Integer.MAX_VALUE
-            Double.MAX_VALUE / (1 + relativeAccuracy)
-        );
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        return Double.compare(relativeAccuracy, ((LinearlyInterpolatedMapping) o).relativeAccuracy) == 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(relativeAccuracy);
+    double correctingFactor() {
+        return 1 / Math.log(2);
     }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
@@ -16,6 +16,13 @@ public class LinearlyInterpolatedMapping extends LogLikeIndexMapping {
         super(relativeAccuracy);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    LinearlyInterpolatedMapping(double gamma, double indexOffset) {
+        super(gamma, indexOffset);
+    }
+
     @Override
     double log(double value) {
         final long longBits = Double.doubleToRawLongBits(value);

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  * <p>
  * That function is scaled depending on the targeted relative accuracy, the base of the logarithm that {@link #log}
  * approximates and how well it geometrically pulls apart values from one another, that is to say, the infimum of
- * |l(x)-l(y)|/|x-y| where x ≠ y and l = log∘exp (log being {@link #log}).
+ * |(l∘exp)(x)-(l∘exp)(y)|/|x-y| where x ≠ y and l = {@link #log}
  */
 abstract class LogLikeIndexMapping implements IndexMapping {
 
@@ -60,7 +60,8 @@ abstract class LogLikeIndexMapping implements IndexMapping {
 
     /**
      * @return a factor that corrects the fact that {@code log} may not geometrically pull apart values from one another
-     * as well as the logarithm
+     * as well as the logarithm; it is equal to the inverse of the infimum of log(b)⋅|(l∘exp)(x)-(l∘exp)(y)|/|x-y| where
+     * x ≠ y, b = {@link #base} and l = {@link #log}
      */
     abstract double correctingFactor();
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -1,0 +1,96 @@
+package com.datadoghq.sketch.ddsketch.mapping;
+
+import java.util.Objects;
+
+/**
+ * A base class for mappings that are derived from a function that approximates the logarithm, namely {@link #log}.
+ * <p>
+ * That function is scaled depending on the targeted relative accuracy, the base of the logarithm that {@link #log}
+ * approximates and how well it geometrically pulls apart values from one another, that is to say, the infimum of
+ * |l(x)-l(y)|/|x-y| where x ≠ y and l = log∘exp (log being {@link #log}).
+ */
+abstract class LogLikeIndexMapping implements IndexMapping {
+
+    private final double relativeAccuracy;
+    private final double multiplier;
+
+    LogLikeIndexMapping(double relativeAccuracy) {
+        if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
+            throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
+        }
+        this.relativeAccuracy = relativeAccuracy;
+        this.multiplier = correctingFactor() * Math.log(base())
+            / (Math.log((1 + relativeAccuracy) / (1 - relativeAccuracy)));
+    }
+
+    /**
+     * @return an approximation of {@code log(1) + Math.log(value) / Math.log(base())}
+     */
+    abstract double log(double value);
+
+    /**
+     * The exact inverse of {@link #log}.
+     *
+     * @return the {@code value} such that {@code log(value) == index}
+     */
+    abstract double logInverse(double index);
+
+    /**
+     * @return the base of the logarithm that {@link #log} approaches
+     */
+    abstract double base();
+
+    /**
+     * @return a factor that corrects the fact that {@code log} may not geometrically pull apart values from one another
+     * as well as the logarithm
+     */
+    abstract double correctingFactor();
+
+    @Override
+    public int index(double value) {
+        final double index = log(value) * multiplier;
+        return index >= 0 ? (int) index : (int) index - 1; // faster than Math::floor
+    }
+
+    @Override
+    public double value(int index) {
+        return logInverse((double) index / multiplier) * (1 + relativeAccuracy);
+    }
+
+    @Override
+    public double relativeAccuracy() {
+        return relativeAccuracy;
+    }
+
+    @Override
+    public double minIndexableValue() {
+        return Math.max(
+            Math.pow(base(), Integer.MIN_VALUE / multiplier - log(1) + 1), // so that index >= Integer.MIN_VALUE
+            Double.MIN_NORMAL * (1 + relativeAccuracy) / (1 - relativeAccuracy)
+        );
+    }
+
+    @Override
+    public double maxIndexableValue() {
+        return Math.min(
+            Math.pow(base(), Integer.MAX_VALUE / multiplier - log(1) - 1), // so that index <= Integer.MAX_VALUE
+            Double.MAX_VALUE / (1 + relativeAccuracy)
+        );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return Double.compare(relativeAccuracy, ((LogLikeIndexMapping) o).relativeAccuracy) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(relativeAccuracy);
+    }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
@@ -16,6 +16,13 @@ public class LogarithmicMapping extends LogLikeIndexMapping {
         super(relativeAccuracy);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    LogarithmicMapping(double gamma, double indexOffset) {
+        super(gamma, indexOffset);
+    }
+
     @Override
     double log(double value) {
         return Math.log(value);

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
@@ -5,71 +5,34 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
-import java.util.Objects;
-
 /**
  * An {@link IndexMapping} that is <i>memory-optimal</i>, that is to say that given a targeted relative accuracy, it
  * requires the least number of indices to cover a given range of values. This is done by logarithmically mapping
  * floating-point values to integers.
  */
-public class LogarithmicMapping implements IndexMapping {
-
-    private final double relativeAccuracy;
-    private final double logGamma;
+public class LogarithmicMapping extends LogLikeIndexMapping {
 
     public LogarithmicMapping(double relativeAccuracy) {
-        if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
-            throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
-        }
-        this.relativeAccuracy = relativeAccuracy;
-        this.logGamma = Math.log((1 + relativeAccuracy) / (1 - relativeAccuracy));
+        super(relativeAccuracy);
     }
 
     @Override
-    public int index(double value) {
-        final double index = Math.log(value) / logGamma;
-        return index >= 0 ? (int) index : (int) index - 1;
+    double log(double value) {
+        return Math.log(value);
     }
 
     @Override
-    public double value(int index) {
-        return Math.exp(index * logGamma) * (1 + relativeAccuracy);
+    double logInverse(double index) {
+        return Math.exp(index);
     }
 
     @Override
-    public double relativeAccuracy() {
-        return relativeAccuracy;
+    double base() {
+        return Math.E;
     }
 
     @Override
-    public double minIndexableValue() {
-        return Math.max(
-            Math.exp((Integer.MIN_VALUE + 1) * logGamma), // so that index >= Integer.MIN_VALUE
-            Double.MIN_NORMAL * Math.exp(logGamma) // so that Math.exp(index * logGamma) >= Double.MIN_NORMAL
-        );
-    }
-
-    @Override
-    public double maxIndexableValue() {
-        return Math.min(
-            Math.exp(Integer.MAX_VALUE * logGamma), // so that index <= Integer.MAX_VALUE
-            Double.MAX_VALUE / (1 + relativeAccuracy) // so that value >= Double.MAX_VALUE
-        );
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        return Double.compare(relativeAccuracy, ((LogarithmicMapping) o).relativeAccuracy) == 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(relativeAccuracy);
+    double correctingFactor() {
+        return 1;
     }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
@@ -18,6 +18,13 @@ public class QuadraticallyInterpolatedMapping extends LogLikeIndexMapping {
         super(relativeAccuracy);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    QuadraticallyInterpolatedMapping(double gamma, double indexOffset) {
+        super(gamma, indexOffset);
+    }
+
     @Override
     double log(double value) {
         final long longBits = Double.doubleToRawLongBits(value);

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
@@ -5,79 +5,41 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
-import java.util.Objects;
-
 /**
  * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link LogarithmicMapping}) by
  * extracting the floor value of the logarithm to the base 2 from the binary representations of floating-point values
  * and quadratically interpolating the logarithm in-between.
  */
-public class QuadraticallyInterpolatedMapping implements IndexMapping {
+public class QuadraticallyInterpolatedMapping extends LogLikeIndexMapping {
 
-    private final double relativeAccuracy;
-    private final double multiplier;
+    private static final double ONE_THIRD = 1.0 / 3.0;
 
     public QuadraticallyInterpolatedMapping(double relativeAccuracy) {
-        if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
-            throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
-        }
-        this.relativeAccuracy = relativeAccuracy;
-        this.multiplier = 1 / (4 * Math.log((1 + relativeAccuracy) / (1 - relativeAccuracy)));
+        super(relativeAccuracy);
     }
 
     @Override
-    public int index(double value) {
+    double log(double value) {
         final long longBits = Double.doubleToRawLongBits(value);
-        final double significandPlusOne = DoubleBitOperationHelper.getSignificandPlusOne(longBits);
-        final double index = multiplier * (
-            (double) DoubleBitOperationHelper.getExponent(longBits) * 3
-                - (significandPlusOne - 5) * (significandPlusOne - 1)
-        );
-        return index >= 0 ? (int) index : (int) index - 1;
+        final double s = DoubleBitOperationHelper.getSignificandPlusOne(longBits);
+        final double e = DoubleBitOperationHelper.getExponent(longBits);
+        return e - (s - 5) * (s - 1) * ONE_THIRD;
     }
 
     @Override
-    public double value(int index) {
-        final double normalizedIndex = (double) index / (multiplier * 3);
-        final long exponent = (long) Math.floor(normalizedIndex);
-        final double significandPlusOne = 3 - Math.sqrt(4 - 3 * (normalizedIndex - exponent));
-        return DoubleBitOperationHelper.buildDouble(exponent, significandPlusOne) * (1 + relativeAccuracy);
+    double logInverse(double index) {
+        final long exponent = (long) Math.floor(index);
+        final double significandPlusOne = 3 - Math.sqrt(4 - 3 * (index - exponent));
+        return DoubleBitOperationHelper.buildDouble(exponent, significandPlusOne);
     }
 
     @Override
-    public double relativeAccuracy() {
-        return relativeAccuracy;
+    double base() {
+        return 2;
     }
 
     @Override
-    public double minIndexableValue() {
-        return Math.max(
-            Math.pow(2, (Integer.MIN_VALUE + 1) / (3 * multiplier) + 1), // so that index >= Integer.MIN_VALUE
-            Double.MIN_NORMAL * (1 + relativeAccuracy) / (1 - relativeAccuracy)
-        );
-    }
-
-    @Override
-    public double maxIndexableValue() {
-        return Math.min(
-            Math.pow(2, Integer.MAX_VALUE / (3 * multiplier) - 1), // so that index <= Integer.MAX_VALUE
-            Double.MAX_VALUE / (1 + relativeAccuracy)
-        );
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        return Double.compare(relativeAccuracy, ((QuadraticallyInterpolatedMapping) o).relativeAccuracy) == 0;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(relativeAccuracy);
+    double correctingFactor() {
+        return 3 / (4 * Math.log(2));
     }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMappingTest.java
@@ -1,9 +1,14 @@
 package com.datadoghq.sketch.ddsketch.mapping;
 
-public class CubicallyInterpolatedMappingTest extends IndexMappingTest {
+class CubicallyInterpolatedMappingTest extends LogLikeIndexMappingTest {
 
     @Override
-    IndexMapping getMapping(double relativeAccuracy) {
+    CubicallyInterpolatedMapping getMapping(double relativeAccuracy) {
         return new CubicallyInterpolatedMapping(relativeAccuracy);
+    }
+
+    @Override
+    CubicallyInterpolatedMapping getMapping(double gamma, double indexOffset) {
+        return new CubicallyInterpolatedMapping(gamma, indexOffset);
     }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.Test;
 
 abstract class IndexMappingTest {
 
-    private final double minTestedRelativeAccuracy = 1e-8;
-    private final double maxTestedRelativeAccuracy = 1 - 1e-3;
-    private final double multiplier = 1 + Math.sqrt(2) * 1e-1;
+    final double minTestedRelativeAccuracy = 1e-8;
+    final double maxTestedRelativeAccuracy = 1 - 1e-3;
+    final double multiplier = 1 + Math.sqrt(2) * 1e-1;
 
     abstract IndexMapping getMapping(double relativeAccuracy);
 
@@ -21,15 +21,18 @@ abstract class IndexMappingTest {
         for (double relativeAccuracy = maxTestedRelativeAccuracy;
              relativeAccuracy >= minTestedRelativeAccuracy;
              relativeAccuracy *= maxTestedRelativeAccuracy) {
+            testAccuracy(getMapping(relativeAccuracy), relativeAccuracy);
+        }
+    }
 
-            final IndexMapping mapping = getMapping(relativeAccuracy);
+    void testAccuracy(IndexMapping mapping, double relativeAccuracy) {
 
-            // Assert that the stated relative accuracy of the mapping is less than or equal to the requested one.
-            RelativeAccuracyTester.assertAccurate(relativeAccuracy, mapping.relativeAccuracy());
+        // Assert that the stated relative accuracy of the mapping is less than or equal to the requested one.
+        RelativeAccuracyTester.assertAccurate(relativeAccuracy, mapping.relativeAccuracy());
 
-            final double maxRelativeAccuracy = assertRelativelyAccurate(mapping);
+        final double maxRelativeAccuracy = assertRelativelyAccurate(mapping);
 
-            // Handy to check that the actual accuracy is consistent with the claimed one (i.e., not much lower).
+        // Handy to check that the actual accuracy is consistent with the claimed one (i.e., not much lower).
             /*
             System.out.println(String.format(
                     "Relative accuracy - Requested: %g, claimed: %g, actual: %g",
@@ -38,7 +41,6 @@ abstract class IndexMappingTest {
                     maxRelativeAccuracy
             ));
              */
-        }
     }
 
     private static double assertRelativelyAccurate(IndexMapping mapping, double value) {

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMappingTest.java
@@ -5,10 +5,15 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
-class LinearlyInterpolatedMappingTest extends IndexMappingTest {
+class LinearlyInterpolatedMappingTest extends LogLikeIndexMappingTest {
 
     @Override
-    IndexMapping getMapping(double relativeAccuracy) {
+    LinearlyInterpolatedMapping getMapping(double relativeAccuracy) {
         return new LinearlyInterpolatedMapping(relativeAccuracy);
+    }
+
+    @Override
+    LinearlyInterpolatedMapping getMapping(double gamma, double indexOffset) {
+        return new LinearlyInterpolatedMapping(gamma, indexOffset);
     }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
@@ -1,0 +1,45 @@
+package com.datadoghq.sketch.ddsketch.mapping;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+abstract class LogLikeIndexMappingTest extends IndexMappingTest {
+
+    private static final double[] TEST_GAMMAS = new double[]{1 + 1e-6, 1.02, 1.5};
+    private static final double[] TEST_INDEX_OFFSETS = new double[]{0, 1, -12.23, 7768.3};
+
+    abstract LogLikeIndexMapping getMapping(double relativeAccuracy);
+
+    abstract LogLikeIndexMapping getMapping(double gamma, double indexOffset);
+
+    @Test
+    @Override
+    void testAccuracy() {
+        super.testAccuracy();
+
+        for (final double gamma : TEST_GAMMAS) {
+            for (final double indexOffset : TEST_INDEX_OFFSETS) {
+                final LogLikeIndexMapping mapping = getMapping(gamma, indexOffset);
+                testAccuracy(mapping, mapping.relativeAccuracy());
+            }
+        }
+    }
+
+    @Test
+    void testOffset() {
+        for (final double gamma : TEST_GAMMAS) {
+            for (final double indexOffset : TEST_INDEX_OFFSETS) {
+                testOffset(getMapping(gamma, indexOffset), indexOffset);
+            }
+        }
+    }
+
+    private void testOffset(LogLikeIndexMapping mapping, double indexOffset) {
+        final double indexOf1 = mapping.index(1);
+        // If 1 is on a bucket boundary, its associated index can be either of the ones of the previous and the next
+        // buckets.
+        assertTrue(Math.ceil(indexOffset) - 1 <= indexOf1);
+        assertTrue(indexOf1 <= Math.floor(indexOffset));
+    }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMappingTest.java
@@ -5,10 +5,15 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
-class LogarithmicMappingTest extends IndexMappingTest {
+class LogarithmicMappingTest extends LogLikeIndexMappingTest {
 
     @Override
-    IndexMapping getMapping(double relativeAccuracy) {
+    LogarithmicMapping getMapping(double relativeAccuracy) {
         return new LogarithmicMapping(relativeAccuracy);
+    }
+
+    @Override
+    LogarithmicMapping getMapping(double gamma, double indexOffset) {
+        return new LogarithmicMapping(gamma, indexOffset);
     }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMappingTest.java
@@ -5,10 +5,15 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
-class QuadraticallyInterpolatedMappingTest extends IndexMappingTest {
+class QuadraticallyInterpolatedMappingTest extends LogLikeIndexMappingTest {
 
     @Override
-    IndexMapping getMapping(double relativeAccuracy) {
+    QuadraticallyInterpolatedMapping getMapping(double relativeAccuracy) {
         return new QuadraticallyInterpolatedMapping(relativeAccuracy);
+    }
+
+    @Override
+    QuadraticallyInterpolatedMapping getMapping(double gamma, double indexOffset) {
+        return new QuadraticallyInterpolatedMapping(gamma, indexOffset);
     }
 }


### PR DESCRIPTION
### What does this PR do?

Refactor log-like mappings (`LogarithmicMapping`, `LinearlyInterpolatedMapping`, `QuadraticallyInterpolatedMapping` and `CubicallyInterpolatedMapping`) so that they use the same base class.

Introduce the `indexOffset` parameter to be able to add a constant shift to the indexes.