### PR TITLE
Use double for bin counters

### DIFF
--- a/src/main/java/com/datadoghq/sketch/QuantileSketch.java
+++ b/src/main/java/com/datadoghq/sketch/QuantileSketch.java
@@ -55,7 +55,7 @@ public interface QuantileSketch<QS extends QuantileSketch<QS>> extends DoubleCon
     /**
      * @return the total number of values that have been added to this sketch
      */
-    long getCount();
+    double getCount();
 
     /**
      * @return the minimum value that has been added to this sketch

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Bin.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Bin.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 public final class Bin {
 
     private final int index;
-    private final long count;
+    private final double count;
 
     /**
      * Constructs a bin.
@@ -22,7 +22,7 @@ public final class Bin {
      * @param count the count of the bin
      * @throws IllegalArgumentException if {@code count} is negative
      */
-    public Bin(int index, long count) {
+    public Bin(int index, double count) {
         if (count < 0) {
             throw new IllegalArgumentException("The count cannot be negative.");
         }
@@ -34,7 +34,7 @@ public final class Bin {
         return index;
     }
 
-    public long getCount() {
+    public double getCount() {
         return count;
     }
 
@@ -48,7 +48,7 @@ public final class Bin {
         }
         final Bin bin = (Bin) o;
         return index == bin.index &&
-            count == bin.count;
+            Double.compare(bin.count, count) == 0;
     }
 
     @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStore.java
@@ -47,7 +47,7 @@ public class CollapsingHighestDenseStore extends CollapsingDenseStore {
 
                 // There will be only one non-empty bucket.
 
-                final long totalCount = getTotalCount();
+                final double totalCount = getTotalCount();
                 resetCounts();
                 offset = newMinIndex;
                 maxIndex = newMaxIndex;
@@ -60,7 +60,7 @@ public class CollapsingHighestDenseStore extends CollapsingDenseStore {
                 if (shift > 0) {
 
                     // Collapse the buckets.
-                    final long collapsedCount = getTotalCount(newMaxIndex + 1, maxIndex);
+                    final double collapsedCount = getTotalCount(newMaxIndex + 1, maxIndex);
                     resetCounts(newMaxIndex + 1, maxIndex);
                     counts[newMaxIndex - offset] += collapsedCount;
                     maxIndex = newMaxIndex;

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStore.java
@@ -47,7 +47,7 @@ public class CollapsingLowestDenseStore extends CollapsingDenseStore {
 
                 // There will be only one non-empty bucket.
 
-                final long totalCount = getTotalCount();
+                final double totalCount = getTotalCount();
                 resetCounts();
                 offset = newMinIndex;
                 minIndex = newMinIndex;
@@ -60,7 +60,7 @@ public class CollapsingLowestDenseStore extends CollapsingDenseStore {
                 if (shift < 0) {
 
                     // Collapse the buckets.
-                    final long collapsedCount = getTotalCount(minIndex, newMinIndex - 1);
+                    final double collapsedCount = getTotalCount(minIndex, newMinIndex - 1);
                     resetCounts(minIndex, newMinIndex - 1);
                     counts[newMinIndex - offset] += collapsedCount;
                     minIndex = newMinIndex;

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
@@ -19,7 +19,7 @@ public abstract class DenseStore implements Store {
     private final int arrayLengthGrowthIncrement;
     private final int arrayLengthOverhead;
 
-    long[] counts;
+    double[] counts;
     int offset;
     int minIndex;
     int maxIndex;
@@ -60,7 +60,7 @@ public abstract class DenseStore implements Store {
     }
 
     @Override
-    public void add(int index, long count) {
+    public void add(int index, double count) {
         if (count < 0) {
             throw new IllegalArgumentException("The count cannot be negative.");
         }
@@ -109,7 +109,7 @@ public abstract class DenseStore implements Store {
         if (isEmpty()) {
 
             final int initialLength = Math.toIntExact(getNewLength(newMinIndex, newMaxIndex));
-            counts = new long[initialLength];
+            counts = new double[initialLength];
             offset = newMinIndex;
             minIndex = newMinIndex;
             maxIndex = newMinIndex;
@@ -195,11 +195,11 @@ public abstract class DenseStore implements Store {
     }
 
     @Override
-    public long getTotalCount() {
+    public double getTotalCount() {
         return getTotalCount(minIndex, maxIndex);
     }
 
-    long getTotalCount(int fromIndex, int toIndex) {
+    double getTotalCount(int fromIndex, int toIndex) {
 
         if (isEmpty()) {
             return 0;
@@ -208,7 +208,7 @@ public abstract class DenseStore implements Store {
         final int fromArrayIndex = Math.max(fromIndex - offset, 0);
         final int toArrayIndex = Math.min(toIndex - offset, counts.length - 1);
 
-        long totalCount = 0;
+        double totalCount = 0;
         for (int arrayIndex = fromArrayIndex; arrayIndex <= toArrayIndex; arrayIndex++) {
             totalCount += counts[arrayIndex];
         }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/SparseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/SparseStore.java
@@ -13,7 +13,7 @@ import java.util.TreeMap;
 
 public class SparseStore implements Store {
 
-    private final NavigableMap<Integer, Long> bins;
+    private final NavigableMap<Integer, Double> bins;
 
     public SparseStore() {
         this.bins = new TreeMap<>();
@@ -25,18 +25,18 @@ public class SparseStore implements Store {
 
     @Override
     public void add(int index) {
-        bins.merge(index, 1L, Long::sum);
+        bins.merge(index, 1.0, Double::sum);
     }
 
     @Override
-    public void add(int index, long count) {
+    public void add(int index, double count) {
         if (count < 0) {
             throw new IllegalArgumentException("The count cannot be negative.");
         }
         if (count == 0) {
             return;
         }
-        bins.merge(index, count, Long::sum);
+        bins.merge(index, count, Double::sum);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class SparseStore implements Store {
         if (bin.getCount() == 0) {
             return;
         }
-        bins.merge(bin.getIndex(), bin.getCount(), Long::sum);
+        bins.merge(bin.getIndex(), bin.getCount(), Double::sum);
     }
 
     @Override
@@ -72,9 +72,9 @@ public class SparseStore implements Store {
         return getBinIterator(bins.descendingMap());
     }
 
-    private static Iterator<Bin> getBinIterator(Map<Integer, Long> bins) {
+    private static Iterator<Bin> getBinIterator(Map<Integer, Double> bins) {
 
-        final Iterator<Entry<Integer, Long>> iterator = bins.entrySet().iterator();
+        final Iterator<Entry<Integer, Double>> iterator = bins.entrySet().iterator();
 
         return new Iterator<Bin>() {
             @Override
@@ -84,7 +84,7 @@ public class SparseStore implements Store {
 
             @Override
             public Bin next() {
-                final Entry<Integer, Long> nextEntry = iterator.next();
+                final Entry<Integer, Double> nextEntry = iterator.next();
                 return new Bin(nextEntry.getKey(), nextEntry.getValue());
             }
         };

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
@@ -33,7 +33,18 @@ public interface Store {
      * @param count a non-negative integer value
      * @throws IllegalArgumentException if {@code count} is negative
      */
-    void add(int index, long count);
+    default void add(int index, long count) {
+        add(index, (double) count);
+    }
+
+    /**
+     * Updates the counter at the specified index.
+     *
+     * @param index the index of the counter to be updated
+     * @param count a non-negative value
+     * @throws IllegalArgumentException if {@code count} is negative
+     */
+    void add(int index, double count);
 
     /**
      * Updates the counter at the specified index.
@@ -64,16 +75,16 @@ public interface Store {
      */
     default boolean isEmpty() {
         return getStream()
-            .mapToLong(Bin::getCount)
+            .mapToDouble(Bin::getCount)
             .allMatch(count -> count == 0);
     }
 
     /**
      * @return the sum of the counters of this store
      */
-    default long getTotalCount() {
+    default double getTotalCount() {
         return getStream()
-            .mapToLong(Bin::getCount)
+            .mapToDouble(Bin::getCount)
             .sum();
     }
 

--- a/src/main/java/com/datadoghq/sketch/gk/GKArray.java
+++ b/src/main/java/com/datadoghq/sketch/gk/GKArray.java
@@ -129,7 +129,7 @@ public class GKArray implements QuantileSketch<GKArray> {
     }
 
     @Override
-    public long getCount() {
+    public double getCount() {
         if (incomingIndex > 0) {
             compress();
         }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStoreTest.java
@@ -21,7 +21,7 @@ abstract class CollapsingHighestDenseStoreTest extends StoreTest {
     }
 
     @Override
-    Map<Integer, Long> getCounts(Bin... bins) {
+    Map<Integer, Double> getCounts(Bin... bins) {
         final OptionalInt minIndex = Arrays.stream(bins)
             .filter(bin -> bin.getCount() > 0)
             .mapToInt(Bin::getIndex)
@@ -33,7 +33,7 @@ abstract class CollapsingHighestDenseStoreTest extends StoreTest {
         return Arrays.stream(bins)
             .collect(Collectors.groupingBy(
                 bin -> Math.min(bin.getIndex(), maxStorableIndex),
-                Collectors.summingLong(Bin::getCount)
+                Collectors.summingDouble(Bin::getCount)
             ));
     }
 

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStoreTest.java
@@ -21,7 +21,7 @@ abstract class CollapsingLowestDenseStoreTest extends StoreTest {
     }
 
     @Override
-    Map<Integer, Long> getCounts(Bin... bins) {
+    Map<Integer, Double> getCounts(Bin... bins) {
         final OptionalInt maxIndex = Arrays.stream(bins)
             .filter(bin -> bin.getCount() > 0)
             .mapToInt(Bin::getIndex)
@@ -33,7 +33,7 @@ abstract class CollapsingLowestDenseStoreTest extends StoreTest {
         return Arrays.stream(bins)
             .collect(Collectors.groupingBy(
                 bin -> Math.max(bin.getIndex(), minStorableIndex),
-                Collectors.summingLong(Bin::getCount)
+                Collectors.summingDouble(Bin::getCount)
             ));
     }
 

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/ExhaustiveStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/ExhaustiveStoreTest.java
@@ -12,11 +12,11 @@ import java.util.stream.Collectors;
 abstract class ExhaustiveStoreTest extends StoreTest {
 
     @Override
-    Map<Integer, Long> getCounts(Bin... bins) {
+    Map<Integer, Double> getCounts(Bin... bins) {
         return Arrays.stream(bins)
             .collect(Collectors.groupingBy(
                 Bin::getIndex,
-                Collectors.summingLong(Bin::getCount)
+                Collectors.summingDouble(Bin::getCount)
             ));
     }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -5,12 +5,11 @@
 
 package com.datadoghq.sketch.ddsketch.store;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.datadoghq.sketch.util.accuracy.AccuracyTester;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -20,39 +19,43 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 abstract class StoreTest {
 
     abstract Store newStore();
 
-    abstract Map<Integer, Long> getCounts(Bin[] bins);
+    abstract Map<Integer, Double> getCounts(Bin[] bins);
 
-    private static Map<Integer, Long> getCounts(Stream<Bin> bins) {
-        return bins.collect(Collectors.groupingBy(Bin::getIndex, Collectors.summingLong(Bin::getCount)));
+    private static Map<Integer, Double> getCounts(Stream<Bin> bins) {
+        return bins.collect(Collectors.groupingBy(Bin::getIndex, Collectors.summingDouble(Bin::getCount)));
     }
 
-    private static Map<Integer, Long> getCounts(Iterator<Bin> bins) {
+    private static Map<Integer, Double> getCounts(Iterator<Bin> bins) {
         return getCounts(StreamSupport.stream(Spliterators.spliteratorUnknownSize(bins, 0), false));
     }
 
-    private static Map<Integer, Long> getNonZeroCounts(Map<Integer, Long> counts) {
+    private static Map<Integer, Double> getNonZeroCounts(Map<Integer, Double> counts) {
         return counts.entrySet().stream()
             .filter(entry -> entry.getValue() > 0)
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
     }
 
-    private static void assertSameCounts(Map<Integer, Long> expected, Map<Integer, Long> actual) {
-        assertEquals(expected, actual);
+    private static void assertSameCounts(Map<Integer, Double> expected, Map<Integer, Double> actual) {
+        assertEquals(new HashSet<>(expected.keySet()), new HashSet<>(actual.keySet()));
+        for (final int key : expected.keySet()) {
+            assertEquals(expected.get(key), actual.get(key), AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
+        }
     }
 
     private void assertEncodes(Bin[] bins, Store store) {
         assertEncodes(getNonZeroCounts(getCounts(bins)), store);
     }
 
-    private static void assertEncodes(Map<Integer, Long> expectedCounts, Store store) {
-        final long expectedTotalCount = expectedCounts.values().stream().mapToLong(count -> count).sum();
-        assertEquals(expectedTotalCount, store.getTotalCount());
+    private static void assertEncodes(Map<Integer, Double> expectedCounts, Store store) {
+        final double expectedTotalCount = expectedCounts.values().stream().mapToDouble(count -> count).sum();
+        assertEquals(expectedTotalCount, store.getTotalCount(), AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
         if (expectedTotalCount == 0) {
             assertTrue(store.isEmpty());
             assertThrows(NoSuchElementException.class, store::getMinIndex);
@@ -186,6 +189,12 @@ abstract class StoreTest {
     }
 
     @Test
+    void testNonIntegerCounts() {
+        testAdding(IntStream.range(0, 10).mapToObj(i -> new Bin(i, Math.log(i + 1))).toArray(Bin[]::new));
+        testAdding(IntStream.range(0, 10).mapToObj(i -> new Bin(-i, Math.log(i + 1))).toArray(Bin[]::new));
+    }
+
+    @Test
     void testExtremeValues() {
         testAdding(Integer.MIN_VALUE);
         testAdding(Integer.MAX_VALUE);
@@ -214,6 +223,18 @@ abstract class StoreTest {
     void testMergingConstant() {
         testMerging(new int[]{ 2, 2 }, new int[]{ 2, 2, 2 }, new int[]{ 2 });
         testMerging(new int[]{ -8, -8 }, new int[]{}, new int[]{ -8 });
+    }
+
+    @Test
+    void testMergingNonIntegerCounts() {
+        testMerging(
+            new Bin[]{ new Bin(3, Math.PI) },
+            new Bin[]{ new Bin(3, Math.E) }
+        );
+        testMerging(
+            new Bin[]{ new Bin(0, 0.1), new Bin(2, 0.3) },
+            new Bin[]{ new Bin(-1, 0.9), new Bin(0, 0.7), new Bin(2, 0.1) }
+        );
     }
 
     @Test

--- a/src/test/java/com/datadoghq/sketch/util/accuracy/AccuracyTester.java
+++ b/src/test/java/com/datadoghq/sketch/util/accuracy/AccuracyTester.java
@@ -14,7 +14,7 @@ import java.util.function.DoubleUnaryOperator;
 public abstract class AccuracyTester {
 
     private static final double DEFAULT_QUANTILE_INCREMENT = 0.01;
-    private static final double FLOATING_POINT_ACCEPTABLE_ERROR = 1e-12;
+    public static final double FLOATING_POINT_ACCEPTABLE_ERROR = 1e-12;
 
     private final double[] sortedValues;
 


### PR DESCRIPTION
### What does this PR do?

Use floating-point values for bin counters.

Floating-point values are useful in a couple of use-cases, including when sampling is involved.

We favor `double` over `float` as adding 1 to a `float` (when adding a value to the sketch) has no effect as soon as we reach 2^23 (8e6), which is quite low and may be problematic in practice. That limit is 2^53 (9e15) for `double`.

Note that _this is a breaking change_, although casting to `double` or `long` when using the exposed methods whose signatures change with this PR should be enough to fix issues.