### PR TITLE
add JOL based footprint tests for DDSketch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.openjdk.jol:jol-core:0.10'
 }
 
 group = 'com.datadoghq'

--- a/src/test/java/com/datadoghq/sketch/ddsketch/footprint/CompositeDistribution.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/footprint/CompositeDistribution.java
@@ -1,0 +1,25 @@
+package com.datadoghq.sketch.ddsketch.footprint;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+final class CompositeDistribution implements Distribution {
+    private final Distribution first;
+    private final Distribution second;
+
+    CompositeDistribution(Distribution first, Distribution second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public String toString() {
+        return first + "/" + second;
+    }
+
+    @Override
+    public double nextValue() {
+        return ThreadLocalRandom.current().nextBoolean()
+                ? first.nextValue()
+                : second.nextValue();
+    }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/footprint/Distribution.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/footprint/Distribution.java
@@ -1,0 +1,10 @@
+package com.datadoghq.sketch.ddsketch.footprint;
+
+@FunctionalInterface
+public interface Distribution {
+    double nextValue();
+
+    default Distribution composeWith(Distribution other) {
+        return new CompositeDistribution(this, other);
+    }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/footprint/Distributions.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/footprint/Distributions.java
@@ -1,0 +1,59 @@
+package com.datadoghq.sketch.ddsketch.footprint;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+public enum Distributions {
+    POINT {
+        @Override
+        protected Distribution create(double... parameters) {
+            return () -> parameters[0];
+        }
+    },
+    UNIFORM {
+        @Override
+        protected Distribution create(double... parameters) {
+            return () -> parameters[0] * ThreadLocalRandom.current().nextDouble();
+        }
+    },
+    NORMAL {
+        @Override
+        protected Distribution create(double... parameters) {
+            return () -> parameters[1] * ThreadLocalRandom.current().nextGaussian() + parameters[0];
+        }
+    },
+    POISSON {
+        @Override
+        protected Distribution create(double... parameters) {
+            return () -> -(Math.log(ThreadLocalRandom.current().nextDouble()) / parameters[0]);
+        }
+    };
+
+    private static final class NamedDistribution implements Distribution {
+        private final Distribution delegate;
+        private final Distributions name;
+        private final double[] params;
+
+        private NamedDistribution(Distribution delegate, Distributions name, double[] params) {
+            this.delegate = delegate;
+            this.name = name;
+            this.params = params;
+        }
+
+        @Override
+        public String toString() {
+            return name + Arrays.toString(params);
+        }
+
+        @Override
+        public double nextValue() {
+            return delegate.nextValue();
+        }
+    }
+
+    public Distribution of(double... parameters) {
+        return new NamedDistribution(create(parameters), this, parameters);
+    }
+
+    protected abstract Distribution create(double... parameters);
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/footprint/FootprintTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/footprint/FootprintTest.java
@@ -1,0 +1,68 @@
+package com.datadoghq.sketch.ddsketch.footprint;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openjdk.jol.info.GraphLayout;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.DoubleFunction;
+import java.util.stream.Stream;
+
+import static com.datadoghq.sketch.ddsketch.footprint.Distributions.*;
+import static java.util.concurrent.TimeUnit.*;
+
+
+public class FootprintTest {
+
+    public static Stream<Arguments> parameters() {
+        // cross product of distribution, sketch constructor and timeunit
+        return Stream.of(
+                POINT.of(42),
+                NORMAL.of(0, 1),
+                NORMAL.of(100, 2),
+                NORMAL.of(100, 50),
+                NORMAL.of(100, 50)
+                        .composeWith(NORMAL.of(1000, 100)),
+                NORMAL.of(100, 50)
+                        .composeWith(NORMAL.of(1000, 100))
+                        .composeWith(NORMAL.of(10000, 1000)),
+                UNIFORM.of(100),
+                POISSON.of(0.1),
+                POISSON.of(0.5),
+                POISSON.of(0.9),
+                POISSON.of(0.1)
+                        .composeWith(POISSON.of(0.9)),
+                POISSON.of(0.5)
+                        .composeWith(POISSON.of(0.9)),
+                POISSON.of(0.7)
+                        .composeWith(POISSON.of(0.9)),
+                POISSON.of(0.01)
+                        .composeWith(POISSON.of(0.99)),
+                POISSON.of(0.001)
+                        .composeWith(POISSON.of(0.999))
+        ).flatMap(dist -> Stream.of(DDSketch::balanced, DDSketch::memoryOptimal, (DoubleFunction<DDSketch>) DDSketch::fast)
+                .flatMap(ctor -> Stream.of(NANOSECONDS, MICROSECONDS, MILLISECONDS)
+                        .map(timeUnit -> Arguments.of(timeUnit, dist, ctor))));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("parameters")
+    public void testFootprint(TimeUnit timeUnit, Distribution distribution, DoubleFunction<DDSketch> sketchConstructor) {
+        for (double relativeError = 1e-5; relativeError < 1e-2; relativeError *= 10) {
+            DDSketch sketch = sketchConstructor.apply(relativeError);
+            for (int i = 0; i < 100_000; ++i) {
+                long nanos = timeUnit.toNanos(Math.round(Math.abs(distribution.nextValue())));
+                sketch.accept(nanos);
+            }
+            printFootprint(distribution, sketch);
+        }
+    }
+
+    private static void printFootprint(Distribution distribution, Object instance) {
+        GraphLayout layout = GraphLayout.parseInstance(instance);
+        System.out.println(distribution);
+        System.out.println(layout.toFootprint());
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds tests which use JOL to measure the footprint of various configurations of `DDSketch` with generators for various shapes of data at different scales, and asserts that the size of the sketch is less than 1KB in each case. 

### Motivation

To understand how heavy sketches are when they are used, and to prevent regressions in sketch footprint. 
