### PR TITLE
add JMH benchmarks for accept and count

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'signing'
     id 'com.google.protobuf' version '0.8.13'
     id 'idea'
+    id 'me.champeau.gradle.jmh' version '0.5.0'
 }
 
 repositories {
@@ -29,6 +30,11 @@ javadoc {
             '  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">' +
             '</script>'
     options.addBooleanOption('-allow-script-in-comments', true)
+}
+
+
+jmh {
+    jmhVersion = '1.26'
 }
 
 task sourcesJar(type: Jar) {
@@ -99,7 +105,6 @@ publishing {
             def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
             def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots'
             url = version.contains('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-
             credentials {
                 username ossrhUsername
                 password ossrhPassword

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/CompositeDistribution.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/CompositeDistribution.java
@@ -1,0 +1,28 @@
+package com.datadoghq.sketch.ddsketch;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+final class CompositeDistribution implements Distribution {
+
+    private final double weight;
+    private final Distribution first;
+    private final Distribution second;
+
+    CompositeDistribution(double weight, Distribution first, Distribution second) {
+        this.weight = weight;
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override
+    public String toString() {
+        return first + "/" + second;
+    }
+
+    @Override
+    public double nextValue() {
+        return ThreadLocalRandom.current().nextDouble() < weight
+                ? first.nextValue()
+                : second.nextValue();
+    }
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/DDSketchOption.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/DDSketchOption.java
@@ -1,0 +1,19 @@
+package com.datadoghq.sketch.ddsketch;
+
+import java.util.function.DoubleFunction;
+
+public enum DDSketchOption {
+    FAST(DDSketch::fast),
+    MEMORY_OPTIMAL(DDSketch::memoryOptimal),
+    BALANCED(DDSketch::balanced);
+
+    private final DoubleFunction<DDSketch> creator;
+
+    DDSketchOption(DoubleFunction<DDSketch> creator) {
+        this.creator = creator;
+    }
+
+    public DDSketch create(double relativeAccuracy) {
+        return creator.apply(relativeAccuracy);
+    }
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/DataGenerator.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/DataGenerator.java
@@ -1,0 +1,27 @@
+package com.datadoghq.sketch.ddsketch;
+
+public enum DataGenerator implements Distribution {
+    POISSON(Distributions.POISSON.of(0.1)),
+    COMPOSITE_POISSON_EXTREME(Distributions.POISSON.of(0.001)
+            .composeWith(Distributions.POISSON.of(0.999))),
+    TRIMODAL_NORMAL(Distributions.NORMAL.of(100, 10)
+            .composeWith(0.33, Distributions.NORMAL.of(1000, 100)
+            .composeWith(0.5, Distributions.NORMAL.of(10000, 1000))));
+
+
+    private final Distribution distribution;
+
+    DataGenerator(Distribution distribution) {
+        this.distribution = distribution;
+    }
+
+    @Override
+    public double nextValue() {
+        return distribution.nextValue();
+    }
+
+    @Override
+    public String toString() {
+        return distribution.toString();
+    }
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/Distribution.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/Distribution.java
@@ -1,0 +1,14 @@
+package com.datadoghq.sketch.ddsketch;
+
+@FunctionalInterface
+public interface Distribution {
+    double nextValue();
+
+    default Distribution composeWith(Distribution other) {
+        return composeWith(0.5, other);
+    }
+
+    default Distribution composeWith(double weight, Distribution other) {
+        return new CompositeDistribution(weight,this, other);
+    }
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/Distributions.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/Distributions.java
@@ -1,0 +1,24 @@
+package com.datadoghq.sketch.ddsketch;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public enum Distributions {
+    NORMAL {
+        @Override
+        protected Distribution create(double... parameters) {
+            return () -> parameters[1] * ThreadLocalRandom.current().nextGaussian() + parameters[0];
+        }
+    },
+    POISSON {
+        @Override
+        protected Distribution create(double... parameters) {
+            return () -> -(Math.log(ThreadLocalRandom.current().nextDouble()) / parameters[0]);
+        }
+    };
+
+    public Distribution of(double... parameters) {
+        return create(parameters);
+    }
+
+    protected abstract Distribution create(double... parameters);
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/AcceptValue.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/AcceptValue.java
@@ -1,0 +1,52 @@
+package com.datadoghq.sketch.ddsketch.benchmarks;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.DDSketchOption;
+import com.datadoghq.sketch.ddsketch.DataGenerator;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.Throughput)
+public class AcceptValue {
+
+    @Param
+    DataGenerator generator;
+
+    @Param({"NANOSECONDS", "MICROSECONDS", "MILLISECONDS"})
+    TimeUnit unit;
+
+    @Param
+    DDSketchOption sketchOption;
+
+    @Param("20")
+    int logCount;
+
+    @Param({"0.01"})
+    double relativeAccuracy;
+
+    DDSketch sketch;
+    private long[] data;
+    int position = 0;
+
+    @Setup(Level.Trial)
+    public void init() {
+        this.sketch = sketchOption.create(relativeAccuracy);
+        this.data = new long[1 << logCount];
+    }
+
+    @Benchmark
+    public Object accept() {
+        sketch.accept(nextValue());
+        // blackhole the sketch to avoid elimination of accept
+        return sketch;
+    }
+
+
+    private long nextValue() {
+        return data[(position++) & (data.length - 1)];
+    }
+
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/ComputeCount.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/ComputeCount.java
@@ -1,0 +1,44 @@
+package com.datadoghq.sketch.ddsketch.benchmarks;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.DDSketchOption;
+import com.datadoghq.sketch.ddsketch.DataGenerator;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class ComputeCount {
+
+    @Param
+    DataGenerator generator;
+
+    @Param({"NANOSECONDS", "MICROSECONDS", "MILLISECONDS"})
+    TimeUnit unit;
+
+    @Param
+    DDSketchOption sketchOption;
+
+    @Param("100000")
+    int count;
+
+    @Param({"0.01"})
+    double relativeAccuracy;
+
+    DDSketch sketch;
+
+    @Setup(Level.Trial)
+    public void init() {
+        this.sketch = sketchOption.create(relativeAccuracy);
+        for (int i = 0; i < count; ++i) {
+            sketch.accept(unit.toNanos(Math.abs(Math.round(generator.nextValue()))));
+        }
+    }
+
+    @Benchmark
+    public double getCount() {
+        return sketch.getCount();
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This adds a JMH module and benchmarks for the `getCount` and `accept` operations.

### Motivation

Understanding performance (and sensitivity to patterns in data thereof) of basic sketch operations; help exploratory performance analysis of the data structure.

### Additional Notes

This PR demonstrates a (perhaps obvious) sensitivity of `DDSketch.getCount` performance to the distribution and granularity of inputs, but verifies that `accept` can be expected to take a handful of nanoseconds.
