### PR TITLE
Favor Math.log1p over Math.log where appropriate

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
@@ -45,7 +45,7 @@ public class BitwiseLinearlyInterpolatedMapping implements IndexMapping {
         if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
             throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
         }
-        final double multiplier = 1 / Math.log(2 / (1 - relativeAccuracy) - 1);
+        final double multiplier = 1 / Math.log1p(2 * relativeAccuracy / (1 - relativeAccuracy));
         return Math.max((int) Math.ceil(Math.log(multiplier) / Math.log(2)), 0);
     }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -26,7 +26,7 @@ abstract class LogLikeIndexMapping implements IndexMapping {
         }
         this.relativeAccuracy = relativeAccuracy;
         this.multiplier = correctingFactor() * Math.log(base())
-            / (Math.log((1 + relativeAccuracy) / (1 - relativeAccuracy)));
+            / (Math.log1p(2 * relativeAccuracy / (1 - relativeAccuracy)));
         this.normalizedIndexOffset = 0;
     }
 
@@ -41,8 +41,8 @@ abstract class LogLikeIndexMapping implements IndexMapping {
         if (gamma <= 1) {
             throw new IllegalArgumentException("gamma must be greater than 1.");
         }
-        this.relativeAccuracy = 1 - 2 / (1 + Math.exp(correctingFactor() * Math.log(gamma)));
-        this.multiplier = Math.log(base()) / Math.log(gamma);
+        this.relativeAccuracy = 1 - 2 / (1 + Math.exp(correctingFactor() * Math.log1p(gamma - 1)));
+        this.multiplier = Math.log(base()) / Math.log1p(gamma - 1);
         this.normalizedIndexOffset = indexOffset - log(1) * this.multiplier;
     }
 


### PR DESCRIPTION
Given that `Math.log1p(x)` is more accurate than `Math.log(1+x)` for small values of `x`.