### PR TITLE
Paginated store

### DIFF
--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/DDSketchOption.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/DDSketchOption.java
@@ -1,11 +1,16 @@
 package com.datadoghq.sketch.ddsketch;
 
+import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
+import com.datadoghq.sketch.ddsketch.store.PaginatedStore;
+import com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore;
+
 import java.util.function.DoubleFunction;
 
 public enum DDSketchOption {
-    FAST(DDSketch::fast),
-    MEMORY_OPTIMAL(DDSketch::memoryOptimal),
-    BALANCED(DDSketch::balanced);
+    FAST(relativeAccuracy -> new DDSketch(new BitwiseLinearlyInterpolatedMapping(relativeAccuracy), UnboundedSizeDenseStore::new)),
+    MEMORY_OPTIMAL(DDSketches::logarithmicUnboundedDense),
+    BALANCED(DDSketches::unboundedDense),
+    PAGINATED(relativeAccuracy -> new DDSketch(new BitwiseLinearlyInterpolatedMapping(relativeAccuracy), PaginatedStore::new));
 
     private final DoubleFunction<DDSketch> creator;
 

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Merge.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Merge.java
@@ -1,0 +1,50 @@
+package com.datadoghq.sketch.ddsketch.benchmarks;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.DDSketchOption;
+import com.datadoghq.sketch.ddsketch.DataGenerator;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class Merge {
+
+    @Param
+    DataGenerator generator;
+
+    @Param({"NANOSECONDS", "MICROSECONDS", "MILLISECONDS"})
+    TimeUnit unit;
+
+    @Param
+    DDSketchOption sketchOption;
+
+    @Param("100000")
+    int count;
+
+    @Param({"0.01"})
+    double relativeAccuracy;
+
+    DDSketch left;
+    DDSketch right;
+
+    @Setup(Level.Trial)
+    public void init() {
+        this.left = sketchOption.create(relativeAccuracy);
+        this.right = sketchOption.create(relativeAccuracy);
+        for (int i = 0; i < count; ++i) {
+            left.accept(unit.toNanos(Math.abs(Math.round(generator.nextValue()))));
+            right.accept(unit.toNanos(Math.abs(Math.round(generator.nextValue()))));
+        }
+    }
+
+    @Benchmark
+    public Object merge() {
+        DDSketch target = sketchOption.create(relativeAccuracy);
+        target.mergeWith(left);
+        target.mergeWith(right);
+        return target;
+    }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -143,24 +143,27 @@ public final class PaginatedStore implements Store {
 
     private void shiftPagesRight(int pageIndex) {
         int requiredExtension = minPageIndex - pageIndex;
-        // check if there is space to shift into
-        boolean canShiftRight = true;
-        for (int i = 0; i < requiredExtension && canShiftRight; ++i) {
-            canShiftRight = null == pages[pages.length - i - 1];
+        if (requiredExtension > 0) {
+            // check if there is space to shift into
+            boolean canShiftRight = true;
+            // check if there are enough null slots at the end of the array to shift into
+            for (int i = 0; i < requiredExtension && canShiftRight && i < pages.length; ++i) {
+                canShiftRight = null == pages[pages.length - i - 1];
+            }
+            if (canShiftRight) {
+                System.arraycopy(pages, 0, pages, requiredExtension, pages.length - requiredExtension);
+            } else {
+                double[][] newPages = new double[pages.length + aligned(requiredExtension)][];
+                System.arraycopy(pages, 0, newPages, requiredExtension, pages.length);
+                this.pages = newPages;
+            }
+            Arrays.fill(pages, 0, requiredExtension, null);
+            this.minPageIndex = pageIndex;
         }
-        if (canShiftRight) {
-            System.arraycopy(pages, 0, pages, requiredExtension, pages.length - requiredExtension);
-        } else {
-            double[][] newPages = new double[pages.length + aligned(requiredExtension)][];
-            System.arraycopy(pages, 0, newPages, requiredExtension, pages.length);
-            this.pages = newPages;
-        }
-        Arrays.fill(pages, 0, requiredExtension, null);
-        this.minPageIndex = pageIndex;
     }
 
     private void extendTo(int pageIndex) {
-        this.pages = Arrays.copyOf(pages, pages.length + aligned(pageIndex - minPageIndex + 1));
+        this.pages = Arrays.copyOf(pages, aligned(pageIndex - minPageIndex + 2));
     }
 
     @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -1,0 +1,271 @@
+package com.datadoghq.sketch.ddsketch.store;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public final class PaginatedStore implements Store {
+
+    private static final int GROWTH = 8;
+    private static final int PAGE_SIZE = 128;
+    private static final int PAGE_MASK = PAGE_SIZE - 1;
+    private static final int PAGE_SHIFT = Integer.bitCount(PAGE_MASK);
+
+    private double[][] pages = null;
+    private int pageOffset;
+
+    public PaginatedStore() {
+        this(0);
+    }
+
+    PaginatedStore(int pageOffset) {
+        this.pageOffset = pageOffset;
+    }
+
+    PaginatedStore(PaginatedStore store) {
+        this(store.pageOffset);
+        this.pages = deepCopy(store.pages);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        // won't initialise any pages unless until a value is added,
+        // and values can't be removed.
+        return null == pages;
+    }
+
+    @Override
+    public int getMinIndex() {
+        if (null != pages) {
+            for (int i = 0; i < pages.length; ++i) {
+                if (null != pages[i]) {
+                    for (int j = 0; j < pages[i].length; ++j) {
+                        if (pages[i][j] != 0D) {
+                            return ((i - pageOffset) << PAGE_SHIFT) + j;
+                        }
+                    }
+                }
+            }
+        }
+        throw new NoSuchElementException();
+    }
+
+    @Override
+    public int getMaxIndex() {
+        if (null != pages) {
+            for (int i = pages.length - 1; i >= 0; --i) {
+                if (null != pages[i]) {
+                    for (int j = pages[i].length - 1; j >= 0; --j) {
+                        if (pages[i][j] != 0D) {
+                            return ((i - pageOffset) << PAGE_SHIFT) + j;
+                        }
+                    }
+                }
+            }
+        }
+        throw new NoSuchElementException();
+    }
+
+    @Override
+    public void add(int index, double count) {
+        if (count > 0) {
+            int alignedIndex = alignedIndex(index);
+            double[] page = getPage(alignedIndex >>> PAGE_SHIFT);
+            page[alignedIndex & PAGE_MASK] += count;
+        }
+    }
+
+    private double[] getPage(int pageIndex) {
+        double[] page = pages[pageIndex];
+        if (null == page) {
+            page = pages[pageIndex] = new double[PAGE_SIZE];
+        }
+        return page;
+    }
+
+    private int alignedIndex(int index) {
+        int pageIndex = index < 0
+                ? -(-index >>> PAGE_SHIFT) - 1
+                : index >>> PAGE_SHIFT;
+        if (null == pages) {
+            lazyInit(pageIndex);
+        } else if (pageIndex + pageOffset < 0) {
+            growBelow(pageIndex);
+        } else if (pageIndex + pageOffset >= pages.length - 1) {
+            growAbove(pageIndex);
+        }
+        return index + (pageOffset << PAGE_SHIFT);
+    }
+
+    private void lazyInit(int pageIndex) {
+        pageOffset = -pageIndex;
+        pages = new double[GROWTH][];
+    }
+
+    private void growBelow(int pageIndex) {
+        int requiredExtension = -pageOffset - pageIndex;
+        // check if there is space to shift into
+        boolean canShiftRight = true;
+        for (int i = 0; i < requiredExtension && canShiftRight; ++i) {
+            canShiftRight = null == pages[pages.length - i - 1];
+        }
+        if (canShiftRight) {
+            System.arraycopy(pages, 0, pages, requiredExtension, pages.length - requiredExtension);
+        } else {
+            double[][] newPages = new double[pages.length + aligned(GROWTH, requiredExtension)][];
+            System.arraycopy(pages, 0, newPages, requiredExtension, pages.length);
+            this.pages = newPages;
+        }
+        Arrays.fill(pages, 0, requiredExtension, null);
+        this.pageOffset = -pageIndex;
+    }
+
+    private void growAbove(int pageIndex) {
+        this.pages = Arrays.copyOf(pages, pages.length + aligned(GROWTH,pageIndex + 1 + pageOffset));
+    }
+
+    @Override
+    public Store copy() {
+        return new PaginatedStore(this);
+    }
+
+    @Override
+    public Iterator<Bin> getAscendingIterator() {
+        return new AscendingIterator();
+    }
+
+    @Override
+    public Iterator<Bin> getDescendingIterator() {
+        return new DescendingIterator();
+    }
+
+    private static int aligned(int alignment, int required) {
+        return (required + alignment - 1) & -alignment;
+    }
+
+    private static double[][] deepCopy(double[][] pages) {
+        if (null != pages) {
+            double[][] copy = new double[pages.length][];
+            for (int i = 0; i < pages.length; ++i) {
+                double[] page = pages[i];
+                if (null != page) {
+                    copy[i] = Arrays.copyOf(page, page.length);
+                }
+            }
+            return copy;
+        }
+        return null;
+    }
+
+    private final class AscendingIterator implements Iterator<Bin> {
+
+        int pageIndex = 0;
+        int valueIndex = 0;
+        double[] page = null;
+        double next = Double.NaN;
+
+        private AscendingIterator() {
+            if (null != pages) {
+                for (int i = 0; i < pages.length; ++i) {
+                    if (pages[i] != null) {
+                        page = pages[i];
+                        pageIndex = i;
+                        next = nextInPage();
+                        break;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !Double.isNaN(next);
+        }
+
+        @Override
+        public Bin next() {
+            double value = next;
+            int index = ((pageIndex - pageOffset) << PAGE_SHIFT) + valueIndex;
+            ++valueIndex;
+            next = nextInPage();
+            if (Double.isNaN(next)) {
+                for (int i = pageIndex + 1; i < pages.length; ++i) {
+                    if (pages[i] != null) {
+                        page = pages[i];
+                        pageIndex = i;
+                        valueIndex = 0;
+                        next = nextInPage();
+                        break;
+                    }
+                }
+            }
+            return new Bin(index, value);
+        }
+
+        private double nextInPage() {
+            for (int i = valueIndex; i < page.length; ++i) {
+                if (page[i] != 0D) {
+                    valueIndex = i;
+                    return page[i];
+                }
+            }
+            return Double.NaN;
+        }
+    }
+
+    private final class DescendingIterator implements Iterator<Bin> {
+
+        int pageIndex = 0;
+        int valueIndex = PAGE_SIZE - 1;
+        double[] page = null;
+        double previous = Double.NaN;
+
+        private DescendingIterator() {
+            if (null != pages) {
+                for (int i = pages.length - 1; i >= 0; --i) {
+                    if (pages[i] != null) {
+                        page = pages[i];
+                        pageIndex = i;
+                        previous = previousInPage();
+                        break;
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return !Double.isNaN(previous);
+        }
+
+        @Override
+        public Bin next() {
+            double value = previous;
+            int index = ((pageIndex - pageOffset) << PAGE_SHIFT) + valueIndex;
+            --valueIndex;
+            previous = previousInPage();
+            if (Double.isNaN(previous)) {
+                for (int i = pageIndex - 1; i >= 0; --i) {
+                    if (pages[i] != null) {
+                        page = pages[i];
+                        pageIndex = i;
+                        valueIndex = page.length - 1;
+                        previous = previousInPage();
+                        break;
+                    }
+                }
+            }
+            return new Bin(index, value);
+        }
+
+        private double previousInPage() {
+            for (int i = valueIndex; i >= 0; --i) {
+                if (page[i] != 0D) {
+                    valueIndex = i;
+                    return page[i];
+                }
+            }
+            return Double.NaN;
+        }
+    }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/footprint/FootprintTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/footprint/FootprintTest.java
@@ -1,6 +1,8 @@
 package com.datadoghq.sketch.ddsketch.footprint;
 
 import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
+import com.datadoghq.sketch.ddsketch.store.PaginatedStore;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -42,7 +44,9 @@ public class FootprintTest {
                         .composeWith(POISSON.of(0.99)),
                 POISSON.of(0.001)
                         .composeWith(POISSON.of(0.999))
-        ).flatMap(dist -> Stream.of(DDSketch::balanced, DDSketch::memoryOptimal, (DoubleFunction<DDSketch>) DDSketch::fast)
+        ).flatMap(dist -> Stream.of(DDSketch::balanced, DDSketch::memoryOptimal,
+                re -> new DDSketch(new BitwiseLinearlyInterpolatedMapping(re), PaginatedStore::new),
+                (DoubleFunction<DDSketch>) DDSketch::fast)
                 .flatMap(ctor -> Stream.of(NANOSECONDS, MICROSECONDS, MILLISECONDS)
                         .map(timeUnit -> Arguments.of(timeUnit, dist, ctor))));
     }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
@@ -1,0 +1,22 @@
+package com.datadoghq.sketch.ddsketch.store;
+
+public class PaginatedStoreTest extends ExhaustiveStoreTest {
+
+
+    @Override
+    Store newStore() {
+        return new PaginatedStore();
+    }
+
+    @Override
+    void testExtremeValues() {
+        // PaginatedStore is not meant to be used with values that are extremely far from one another as it
+        // would allocate an excessively large array.
+    }
+
+    @Override
+    void testMergingExtremeValues() {
+        // PaginatedStore is not meant to be used with values that are extremely far from one another as it
+        // would allocate an excessively large array.
+    }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
@@ -1,6 +1,5 @@
 package com.datadoghq.sketch.ddsketch.store;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
@@ -1,5 +1,17 @@
 package com.datadoghq.sketch.ddsketch.store;
 
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Iterator;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 public class PaginatedStoreTest extends ExhaustiveStoreTest {
 
 
@@ -18,5 +30,39 @@ public class PaginatedStoreTest extends ExhaustiveStoreTest {
     void testMergingExtremeValues() {
         // PaginatedStore is not meant to be used with values that are extremely far from one another as it
         // would allocate an excessively large array.
+    }
+
+    public static Stream<Arguments> affineTransformations() {
+        return Stream.of(
+                Arguments.of(1, 0),
+                Arguments.of(127, 1),
+                Arguments.of(128, 0),
+                Arguments.of(128, 1),
+                Arguments.of(129, 0),
+                Arguments.of(129, 1),
+                Arguments.of(-127, 1),
+                Arguments.of(-128, 0),
+                Arguments.of(-128, 1),
+                Arguments.of(-129, 0),
+                Arguments.of(-129, 1)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("affineTransformations")
+    public void shouldBeEquivalentToUnboundedSizeDenseStore(int m, int c) {
+        Store paginatedStore = newStore();
+        UnboundedSizeDenseStore denseStore = new UnboundedSizeDenseStore();
+        IntStream.range(0, 1000).map(x -> m * x + c).forEach(x -> {
+            paginatedStore.add(x);
+            denseStore.add(x);
+        });
+        Iterator<Bin> pit = paginatedStore.getAscendingIterator();
+        Iterator<Bin> dit = denseStore.getAscendingIterator();
+        while (pit.hasNext() && dit.hasNext()) {
+            assertEquals(dit.next().getIndex(), pit.next().getIndex());
+        }
+        assertFalse(pit.hasNext());
+        assertFalse(dit.hasNext());
     }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -219,6 +219,9 @@ abstract class StoreTest {
         testMerging(new int[]{ -10000 }, new int[]{ 10000 });
         testMerging(new int[]{ 10000 }, new int[]{ -10000 });
         testMerging(new int[]{ 10000 }, new int[]{ -10000 }, new int[]{ 0 });
+        testMerging(new int[]{ -10000, 10000 }, new int[]{ -5000, 5000 });
+        testMerging(new int[]{ -5000, 5000 }, new int[]{ -10000, 10000 });
+        testMerging(new int[]{ -5000, 10000 }, new int[]{ -10000, 5000 });
         testMerging(new int[]{ 10000, 0 }, new int[]{ -10000 }, new int[]{ 0 });
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR provides a store which avoids storing ranges of zeros by storing counts in a paginated array.

### Motivation

To reduce worst case footprint when data is bimodal leading to large ranges of zeros, without affecting (or needing to reason about) relative error.

### Additional Notes

I don't expect to merge this as is, because `DDSketch` is being removed and I need somewhere to put the factory method, so expect to rebase against #28 during a review. 

This can have a sizeable impact on footprint:

```
POISSON[0.01]/POISSON[0.99]
com.datadoghq.sketch.ddsketch.DDSketch@423158f0d footprint:
     COUNT       AVG       SUM   DESCRIPTION
       677      1040    704080   [D
         1     26224     26224   [[D
         1        48        48   com.datadoghq.sketch.ddsketch.DDSketch
         1        32        32   com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping
         1        24        24   com.datadoghq.sketch.ddsketch.store.PaginatedStore
       681              730408   (total)


POISSON[0.01]/POISSON[0.99]
com.datadoghq.sketch.ddsketch.DDSketch@5c1d7c70d footprint:
     COUNT       AVG       SUM   DESCRIPTION
       301      1040    313040   [D
         1      3920      3920   [[D
         1        48        48   com.datadoghq.sketch.ddsketch.DDSketch
         1        32        32   com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping
         1        24        24   com.datadoghq.sketch.ddsketch.store.PaginatedStore
       305              317064   (total)


POISSON[0.01]/POISSON[0.99]
com.datadoghq.sketch.ddsketch.DDSketch@4b5ee172d footprint:
     COUNT       AVG       SUM   DESCRIPTION
        36      1040     37440   [D
         1       304       304   [[D
         1        48        48   com.datadoghq.sketch.ddsketch.DDSketch
         1        32        32   com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping
         1        24        24   com.datadoghq.sketch.ddsketch.store.PaginatedStore
        40               37848   (total)



POISSON[0.01]/POISSON[0.99]
com.datadoghq.sketch.ddsketch.DDSketch@2271c060d footprint:
     COUNT       AVG       SUM   DESCRIPTION
         1   5255184   5255184   [D
         1        48        48   com.datadoghq.sketch.ddsketch.DDSketch
         1        32        32   com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping
         1        40        40   com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore
         4             5255304   (total)


POISSON[0.01]/POISSON[0.99]
com.datadoghq.sketch.ddsketch.DDSketch@3fbcff15d footprint:
     COUNT       AVG       SUM   DESCRIPTION
         1    647696    647696   [D
         1        48        48   com.datadoghq.sketch.ddsketch.DDSketch
         1        32        32   com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping
         1        40        40   com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore
         4              647816   (total)


POISSON[0.01]/POISSON[0.99]
com.datadoghq.sketch.ddsketch.DDSketch@7694bfabd footprint:
     COUNT       AVG       SUM   DESCRIPTION
         1     41488     41488   [D
         1        48        48   com.datadoghq.sketch.ddsketch.DDSketch
         1        32        32   com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping
         1        40        40   com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore
         4               41608   (total)
```

It would also be simple to implement a much faster merge routine which could be vectorized by Hotspot/C2 in `PaginatedStore` which I may contribute at a later date (but I don't immediately need faster aggregation).