### PR TITLE
add QuantileSketch.clear() so memory allocated by sketch can be reused

### DIFF
--- a/src/main/java/com/datadoghq/sketch/QuantileSketch.java
+++ b/src/main/java/com/datadoghq/sketch/QuantileSketch.java
@@ -53,6 +53,13 @@ public interface QuantileSketch<QS extends QuantileSketch<QS>> extends DoubleCon
     }
 
     /**
+     * Sets all counts in the sketch to zero.
+     * The sketch behaves as if it were empty after this call,
+     * but any allocated memory is not released.
+     */
+    void clear();
+
+    /**
      * @return the total number of values that have been added to this sketch
      */
     double getCount();

--- a/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
@@ -246,6 +246,13 @@ public class DDSketch implements QuantileSketch<DDSketch> {
     }
 
     @Override
+    public void clear() {
+        negativeValueStore.clear();
+        positiveValueStore.clear();
+        zeroCount = 0D;
+    }
+
+    @Override
     public double getCount() {
         return zeroCount + negativeValueStore.getTotalCount() + positiveValueStore.getTotalCount();
     }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingDenseStore.java
@@ -26,4 +26,10 @@ abstract class CollapsingDenseStore extends DenseStore {
     long getNewLength(int newMinIndex, int newMaxIndex) {
         return Math.min(super.getNewLength(newMinIndex, newMaxIndex), maxNumBins);
     }
+
+    @Override
+    public void clear() {
+        super.clear();
+        isCollapsed = false;
+    }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
@@ -47,7 +47,7 @@ public abstract class DenseStore implements Store {
     DenseStore(DenseStore store) {
         this.arrayLengthGrowthIncrement = store.arrayLengthGrowthIncrement;
         this.arrayLengthOverhead = store.arrayLengthOverhead;
-        this.counts = store.counts == null ? null : Arrays.copyOf(store.counts, store.counts.length);
+        this.counts = store.counts == null || store.isEmpty() ? null : Arrays.copyOf(store.counts, store.counts.length);
         this.offset = store.offset;
         this.minIndex = store.minIndex;
         this.maxIndex = store.maxIndex;
@@ -80,6 +80,16 @@ public abstract class DenseStore implements Store {
         counts[arrayIndex] += bin.getCount();
     }
 
+    @Override
+    public void clear() {
+        if (null != counts) {
+            Arrays.fill(counts, 0D);
+        }
+        maxIndex = Integer.MIN_VALUE;
+        minIndex = Integer.MAX_VALUE;
+        offset = 0;
+    }
+
     /**
      * Normalize the store, if necessary, so that the counter of the specified index can be updated.
      *
@@ -109,7 +119,9 @@ public abstract class DenseStore implements Store {
         if (isEmpty()) {
 
             final int initialLength = Math.toIntExact(getNewLength(newMinIndex, newMaxIndex));
-            counts = new double[initialLength];
+            if (null == counts || initialLength >= counts.length) {
+                counts = new double[initialLength];
+            }
             offset = newMinIndex;
             minIndex = newMinIndex;
             maxIndex = newMinIndex;

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
@@ -47,10 +47,17 @@ public abstract class DenseStore implements Store {
     DenseStore(DenseStore store) {
         this.arrayLengthGrowthIncrement = store.arrayLengthGrowthIncrement;
         this.arrayLengthOverhead = store.arrayLengthOverhead;
-        this.counts = store.counts == null || store.isEmpty() ? null : Arrays.copyOf(store.counts, store.counts.length);
-        this.offset = store.offset;
         this.minIndex = store.minIndex;
         this.maxIndex = store.maxIndex;
+        if (store.counts != null && !store.isEmpty()) {
+            this.counts = Arrays.copyOfRange(store.counts,
+                    store.minIndex - store.offset,
+                    store.maxIndex - store.offset + 1);
+            this.offset = store.minIndex;
+        } else {
+            // should be zero anyway, but just in case
+            this.offset = store.offset;
+        }
     }
 
     @Override
@@ -124,7 +131,7 @@ public abstract class DenseStore implements Store {
             }
             offset = newMinIndex;
             minIndex = newMinIndex;
-            maxIndex = newMinIndex;
+            maxIndex = newMaxIndex;
             adjust(newMinIndex, newMaxIndex);
 
         } else if (newMinIndex >= offset && newMaxIndex < (long) offset + counts.length) {

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -40,14 +40,14 @@ public final class PaginatedStore implements Store {
 
     PaginatedStore(PaginatedStore store) {
         this(store.minPageIndex);
-        this.pages = deepCopy(store.pages);
+        this.pages = store.isEmpty() ? null : deepCopy(store.pages);
     }
 
     @Override
     public boolean isEmpty() {
         // won't initialise any pages until a value is added,
         // and values can't be removed.
-        return null == pages;
+        return minPageIndex == Integer.MAX_VALUE;
     }
 
     @Override
@@ -123,7 +123,7 @@ public final class PaginatedStore implements Store {
         if (pageIndex < minPageIndex) {
             // then space needs to be made before the first page,
             // unless this is the first insertion
-            if (null == pages) {
+            if (isEmpty()) {
                 lazyInit(pageIndex);
             } else {
                 shiftPagesRight(pageIndex);
@@ -138,7 +138,9 @@ public final class PaginatedStore implements Store {
 
     private void lazyInit(int pageIndex) {
         minPageIndex = pageIndex;
-        pages = new double[GROWTH][];
+        if (null == pages) {
+            pages = new double[GROWTH][];
+        }
     }
 
     private void shiftPagesRight(int pageIndex) {
@@ -247,6 +249,18 @@ public final class PaginatedStore implements Store {
     @Override
     public Store copy() {
         return new PaginatedStore(this);
+    }
+
+    @Override
+    public void clear() {
+        if (null != pages) {
+            for (double[] page : pages) {
+                if (null != page) {
+                    Arrays.fill(page, 0D);
+                }
+            }
+        }
+        minPageIndex = Integer.MAX_VALUE;
     }
 
     @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/SparseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/SparseStore.java
@@ -53,6 +53,11 @@ public class SparseStore implements Store {
     }
 
     @Override
+    public void clear() {
+        this.bins.clear();
+    }
+
+    @Override
     public int getMinIndex() {
         return bins.firstKey();
     }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
@@ -71,6 +71,13 @@ public interface Store {
      */
     Store copy();
 
+
+    /**
+     * Zeros all counts in the store. The store behaves as if
+     * empty after this call, but no underlying storage is released.
+     */
+    void clear();
+
     /**
      * @return {@code true} iff the {@code Store} does not contain any non-zero counter
      */

--- a/src/main/java/com/datadoghq/sketch/gk/GKArray.java
+++ b/src/main/java/com/datadoghq/sketch/gk/GKArray.java
@@ -129,6 +129,14 @@ public class GKArray implements QuantileSketch<GKArray> {
     }
 
     @Override
+    public void clear() {
+        entries.clear();
+        incomingIndex = 0;
+        compressedCount = 0;
+        minValue = Double.MAX_VALUE;
+    }
+
+    @Override
     public double getCount() {
         if (incomingIndex > 0) {
             compress();

--- a/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
@@ -32,63 +32,80 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
 
         final QS emptySketch = newSketch();
 
-        assertThrows(
-            NoSuchElementException.class,
-            emptySketch::getMinValue
-        );
-
-        assertThrows(
-            NoSuchElementException.class,
-            emptySketch::getMaxValue
-        );
-
-        assertThrows(
-            NoSuchElementException.class,
-            () -> emptySketch.getValueAtQuantile(0.5)
-        );
-
-        assertThrows(
-            NoSuchElementException.class,
-            () -> emptySketch.getValuesAtQuantiles(new double[]{ 0.5 })
-        );
-
-        assertThrows(
-            NullPointerException.class,
-            () -> emptySketch.mergeWith(null)
-        );
-
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> emptySketch.accept(0, -1)
-        );
-
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> emptySketch.accept(1, -1)
-        );
+        emptySketchAssertions(emptySketch);
 
         final QS nonEmptySketch = newSketch();
         nonEmptySketch.accept(0);
+        nonEmptySketchAssertions(nonEmptySketch);
 
+    }
+
+    private void emptySketchAssertions(QS emptySketch) {
         assertThrows(
-            IllegalArgumentException.class,
-            () -> nonEmptySketch.getValueAtQuantile(-0.1)
+                NoSuchElementException.class,
+                emptySketch::getMinValue
         );
 
         assertThrows(
-            IllegalArgumentException.class,
-            () -> nonEmptySketch.getValueAtQuantile(1.1)
+                NoSuchElementException.class,
+                emptySketch::getMaxValue
         );
 
         assertThrows(
-            IllegalArgumentException.class,
-            () -> nonEmptySketch.getValuesAtQuantiles(new double[]{ 0, -0.1 })
+                NoSuchElementException.class,
+                () -> emptySketch.getValueAtQuantile(0.5)
         );
 
         assertThrows(
-            IllegalArgumentException.class,
-            () -> nonEmptySketch.getValuesAtQuantiles(new double[]{ 1.1, 1 })
+                NoSuchElementException.class,
+                () -> emptySketch.getValuesAtQuantiles(new double[]{ 0.5 })
         );
+
+        assertThrows(
+                NullPointerException.class,
+                () -> emptySketch.mergeWith(null)
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> emptySketch.accept(0, -1)
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> emptySketch.accept(1, -1)
+        );
+    }
+
+    private void nonEmptySketchAssertions(QS nonEmptySketch) {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> nonEmptySketch.getValueAtQuantile(-0.1)
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> nonEmptySketch.getValueAtQuantile(1.1)
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> nonEmptySketch.getValuesAtQuantiles(new double[]{ 0, -0.1 })
+        );
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> nonEmptySketch.getValuesAtQuantiles(new double[]{ 1.1, 1 })
+        );
+    }
+
+    @Test
+    protected void clearSketchShouldBehaveEmpty() {
+        final QS sketch = newSketch();
+        sketch.accept(0);
+        sketch.clear();
+        assertTrue(sketch.isEmpty());
+        emptySketchAssertions(sketch);
     }
 
     protected void test(boolean merged, double[] values, QS sketch) {

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -171,6 +171,24 @@ abstract class StoreTest {
     }
 
     @Test
+    void testClear() {
+        final Store store = newStore();
+        assertTrue(store.isEmpty());
+        store.clear();
+        assertTrue(store.isEmpty());
+        int[] beforeClear = IntStream.range(0, 10000).toArray();
+        Arrays.stream(beforeClear).forEach(store::add);
+        test(toBins(beforeClear), store);
+        assertFalse(store.isEmpty());
+        store.clear();
+        assertTrue(store.isEmpty());
+        // add some more values at an offset
+        int[] afterClear = IntStream.range(10000, 20000).toArray();
+        Arrays.stream(afterClear).forEach(store::add);
+        test(toBins(afterClear), store);
+    }
+
+    @Test
     void testDecreasingLinearly() {
         testAdding(IntStream.range(0, 10000).map(i -> -i).toArray());
     }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -288,4 +288,13 @@ abstract class StoreTest {
         final Store copy = store.copy();
         test(bins, copy);
     }
+
+    @Test
+    public void testCountsPreservedAfterCopy() {
+        Store store = newStore();
+        store.add(10);
+        store.add(100);
+        Store copy = store.copy();
+        assertEquals(store.getTotalCount(), copy.getTotalCount(), 1e-7);
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Makes it possible to clear a sketch, so that it behaves as if it's empty, but can hang on to allocated memory.

### Motivation

We report latencies in epochs, and don't want recorded values to bleed between epochs. Currently this requires allocating a new sketch, but we would like to reuse the sketch since it will probably be able to reuse the allocated memory.

### Additional Notes

Anything else we should know when reviewing?
