### PR TITLE
Fix the serialization of BitwiseLinearlyInterpolatedMapping

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
@@ -110,7 +110,7 @@ public class BitwiseLinearlyInterpolatedMapping implements IndexMapping {
     public com.datadoghq.sketch.ddsketch.proto.IndexMapping toProto() {
         return com.datadoghq.sketch.ddsketch.proto.IndexMapping.newBuilder()
             .setGamma(Math.pow(2, 1.0 / multiplier))
-            .setIndexOffset(multiplier)
+            .setIndexOffset(0)
             .setInterpolation(com.datadoghq.sketch.ddsketch.proto.IndexMapping.Interpolation.LINEAR)
             .build();
     }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMappingTest.java
@@ -22,11 +22,10 @@ class BitwiseLinearlyInterpolatedMappingTest extends IndexMappingTest {
     void testProtoRoundTrip() {
         final BitwiseLinearlyInterpolatedMapping mapping = getMapping(1e-2);
         final IndexMapping roundTripMapping = IndexMapping.fromProto(mapping.toProto());
-        final IndexMapping expectedMapping = new LinearlyInterpolatedMapping(mapping.relativeAccuracy());
-        assertEquals(expectedMapping.getClass(), roundTripMapping.getClass());
-        assertEquals(expectedMapping.relativeAccuracy(), roundTripMapping.relativeAccuracy(),
+        assertEquals(LinearlyInterpolatedMapping.class, roundTripMapping.getClass());
+        assertEquals(mapping.relativeAccuracy(), roundTripMapping.relativeAccuracy(),
             AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
-        assertEquals(expectedMapping.value(0), roundTripMapping.value(0),
+        assertEquals(mapping.value(0), roundTripMapping.value(0),
             AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
     }
 }


### PR DESCRIPTION
The index offset is improperly set when serializing `BitwiseLinearlyInterpolatedMapping`, which causes the deserialized mapping to be different from the initial mapping (see https://github.com/DataDog/sketches-java/pull/33).