### PR TITLE
Add a store that allows merging contiguous buckets to cap its memory size

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
@@ -158,9 +158,12 @@ public class DDSketch implements QuantileSketch<DDSketch> {
     }
 
     public double getRelativeAccuracy() {
-        return Math.pow(
-            indexMapping.relativeAccuracy(),
+        final double mappingRelativeAccuracy = indexMapping.relativeAccuracy();
+        final double mappingGamma = (1 + mappingRelativeAccuracy) / (1 - mappingRelativeAccuracy);
+        final double adjustedGamma = Math.pow(
+            mappingGamma,
             1 + Math.max(negativeValueStore.maxShift(), positiveValueStore.maxShift()));
+        return (adjustedGamma - 1) / (adjustedGamma + 1);
     }
 
     /**

--- a/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
@@ -157,6 +157,12 @@ public class DDSketch implements QuantileSketch<DDSketch> {
         return positiveValueStore;
     }
 
+    public double getRelativeAccuracy() {
+        return Math.pow(
+            indexMapping.relativeAccuracy(),
+            1 + Math.max(negativeValueStore.maxShift(), positiveValueStore.maxShift()));
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
@@ -154,6 +154,13 @@ public interface Store {
     Iterator<Bin> getDescendingIterator();
 
     /**
+     * @return to what extent an inserted index can be shifted
+     */
+    default int maxShift() {
+        return 0;
+    }
+
+    /**
      * Generates a protobuf representation of this {@code Store}.
      *
      * @return a protobuf representation of this {@code Store}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/BoundedSizeRescalingStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/BoundedSizeRescalingStore.java
@@ -11,8 +11,9 @@ import java.util.function.Supplier;
  * <p>
  * Bucket merging happens when rescaling the store. The rescaling factor is always a power of 2, so that the size of the
  * merged buckets (that is to say the number of contiguous indices that are mapped to the same counter) can be expressed
- * as \(2^n\). The relative accuracy of a sketch that uses such a store is \(\alpha^{2^n}\), where \(\alpha\) is the
- * relative accuracy of the index mapping that the store uses.
+ * as \(2^n\). The relative accuracy of a sketch that uses such a store is \(\frac{\gamma^{2^n}-1}{\gamma^{2^n}+1}\),
+ * where \(\gamma=\frac{1+\alpha}{1-\alpha}\) and \(\alpha\) is the relative accuracy of the index mapping that the
+ * store uses. For small values of \(\alpha\), this is roughly \(2^n\alpha\).
  */
 public class BoundedSizeRescalingStore extends RescalingStore {
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/BoundedSizeRescalingStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/BoundedSizeRescalingStore.java
@@ -1,0 +1,54 @@
+package com.datadoghq.sketch.ddsketch.store.rescaling;
+
+import com.datadoghq.sketch.ddsketch.store.Store;
+import com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore;
+
+import java.util.function.Supplier;
+
+/**
+ * A store with bounded memory size that merges contiguous buckets if necessary, hence uniformly degrading the accuracy
+ * of the sketch that uses it.
+ * <p>
+ * Bucket merging happens when rescaling the store. The rescaling factor is always a power of 2, so that the size of the
+ * merged buckets (that is to say the number of contiguous indices that are mapped to the same counter) can be expressed
+ * as \(2^n\). The relative accuracy of a sketch that uses such a store is \(\alpha^{2^n}\), where \(\alpha\) is the
+ * relative accuracy of the index mapping that the store uses.
+ */
+public class BoundedSizeRescalingStore extends RescalingStore {
+
+    private final int maxNumBins;
+
+    public BoundedSizeRescalingStore(int maxNumBins) {
+        super(UnboundedSizeDenseStore::new);
+        this.maxNumBins = maxNumBins;
+    }
+
+    private BoundedSizeRescalingStore(Supplier<? extends Store> storeSupplier, Store delegate, int scalingFactor, int maxNumBins) {
+        super(storeSupplier, delegate, scalingFactor);
+        this.maxNumBins = maxNumBins;
+    }
+
+    @Override
+    protected int shouldRescale() {
+        if (delegate.isEmpty()) {
+            return 1;
+        }
+        // FIXME: this is not the actual number of allocated bins
+        final int span = delegate.getMaxIndex() - delegate.getMinIndex();
+        if (span > maxNumBins) {
+            // Rescale by the smallest possible power of 2
+            int rescalingFactor = 2;
+            while (span > maxNumBins * rescalingFactor) {
+                rescalingFactor = Math.multiplyExact(rescalingFactor, 2);
+            }
+            return rescalingFactor;
+        } else {
+            return 1;
+        }
+    }
+
+    @Override
+    public Store copy() {
+        return new BoundedSizeRescalingStore(storeSupplier, delegate.copy(), scalingFactor, maxNumBins);
+    }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/RescalingStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/RescalingStore.java
@@ -1,0 +1,125 @@
+package com.datadoghq.sketch.ddsketch.store.rescaling;
+
+import com.datadoghq.sketch.ddsketch.store.Bin;
+import com.datadoghq.sketch.ddsketch.store.Store;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+public abstract class RescalingStore implements Store {
+
+    protected final Supplier<? extends Store> storeSupplier;
+
+    protected Store delegate;
+    protected int scalingFactor = 1;
+
+    public RescalingStore(Supplier<? extends Store> storeSupplier) {
+        this.storeSupplier = storeSupplier;
+        this.delegate = storeSupplier.get();
+    }
+
+    protected RescalingStore(Supplier<? extends Store> storeSupplier, Store delegate, int scalingFactor) {
+        this.storeSupplier = storeSupplier;
+        this.delegate = delegate;
+        this.scalingFactor = scalingFactor;
+    }
+
+    /**
+     * @return the rescaling factor > 1 if it should rescale
+     */
+    protected abstract int shouldRescale();
+
+    /**
+     * Merge contiguous buckets.
+     *
+     * @param rescalingFactor the factor to be compounded with the current one
+     */
+    protected final void rescale(int rescalingFactor) {
+        final Store newDelegate = storeSupplier.get();
+        final int newScalingFactor = scalingFactor * rescalingFactor;
+        delegate.getStream()
+            .map(bin -> new Bin(Math.floorDiv(bin.getIndex(), rescalingFactor), bin.getCount()))
+            .forEach(newDelegate::add);
+        delegate = newDelegate;
+        scalingFactor = newScalingFactor;
+    }
+
+    @Override
+    public void add(int index, double count) {
+        delegate.add(Math.floorDiv(index, scalingFactor), count);
+        final int rescalingFactor = shouldRescale();
+        if (rescalingFactor > 1) {
+            rescale(rescalingFactor);
+        }
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+
+    @Override
+    public void mergeWith(Store store) {
+        if (!(store instanceof RescalingStore) || delegate.maxShift() > 0) {
+            // FIXME: implement
+            throw new UnsupportedOperationException();
+        }
+        final RescalingStore that = (RescalingStore) store;
+        final int newScalingFactor = lcm(this.scalingFactor, that.scalingFactor);
+        if (newScalingFactor > scalingFactor) {
+            rescale(newScalingFactor / scalingFactor);
+        }
+        that.getStream().forEach(this::add);
+    }
+
+    @Override
+    public Iterator<Bin> getAscendingIterator() {
+        final Iterator<Bin> delegateIterator = delegate.getAscendingIterator();
+        return new Iterator<Bin>() {
+            @Override
+            public boolean hasNext() {
+                return delegateIterator.hasNext();
+            }
+
+            @Override
+            public Bin next() {
+                final Bin bin = delegateIterator.next();
+                return new Bin(bin.getIndex() * scalingFactor, bin.getCount());
+            }
+        };
+    }
+
+    @Override
+    public Iterator<Bin> getDescendingIterator() {
+        final Iterator<Bin> delegateIterator = delegate.getDescendingIterator();
+        return new Iterator<Bin>() {
+            @Override
+            public boolean hasNext() {
+                return delegateIterator.hasNext();
+            }
+
+            @Override
+            public Bin next() {
+                final Bin bin = delegateIterator.next();
+                return new Bin(bin.getIndex() * scalingFactor, bin.getCount());
+            }
+        };
+    }
+
+    @Override
+    public int maxShift() {
+        return scalingFactor * (delegate.maxShift() + 1) - 1;
+    }
+
+    private static int gcd(int a, int b) {
+        if (b == 0) {
+            return a;
+        } else {
+            return gcd(b, a % b);
+        }
+    }
+
+    private static int lcm(int a, int b) {
+        return Math.multiplyExact(a, b / gcd(a, b));
+    }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/RescalingStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/RescalingStore.java
@@ -56,6 +56,7 @@ public abstract class RescalingStore implements Store {
     @Override
     public void clear() {
         delegate.clear();
+        scalingFactor = 1;
     }
 
     @Override

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStoreTest.java
@@ -16,12 +16,12 @@ abstract class CollapsingHighestDenseStoreTest extends StoreTest {
     abstract int maxNumBins();
 
     @Override
-    Store newStore() {
+    protected Store newStore() {
         return new CollapsingHighestDenseStore(maxNumBins());
     }
 
     @Override
-    Map<Integer, Double> getCounts(Bin... bins) {
+    protected Map<Integer, Double> getCounts(Store store, Bin... bins) {
         final OptionalInt minIndex = Arrays.stream(bins)
             .filter(bin -> bin.getCount() > 0)
             .mapToInt(Bin::getIndex)

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStoreTest.java
@@ -16,12 +16,12 @@ abstract class CollapsingLowestDenseStoreTest extends StoreTest {
     abstract int maxNumBins();
 
     @Override
-    Store newStore() {
+    protected Store newStore() {
         return new CollapsingLowestDenseStore(maxNumBins());
     }
 
     @Override
-    Map<Integer, Double> getCounts(Bin... bins) {
+    protected Map<Integer, Double> getCounts(Store store, Bin... bins) {
         final OptionalInt maxIndex = Arrays.stream(bins)
             .filter(bin -> bin.getCount() > 0)
             .mapToInt(Bin::getIndex)

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/ExhaustiveStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/ExhaustiveStoreTest.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 abstract class ExhaustiveStoreTest extends StoreTest {
 
     @Override
-    Map<Integer, Double> getCounts(Bin... bins) {
+    protected Map<Integer, Double> getCounts(Store store, Bin... bins) {
         return Arrays.stream(bins)
             .collect(Collectors.groupingBy(
                 Bin::getIndex,

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/PaginatedStoreTest.java
@@ -15,18 +15,18 @@ public class PaginatedStoreTest extends ExhaustiveStoreTest {
 
 
     @Override
-    Store newStore() {
+    protected Store newStore() {
         return new PaginatedStore();
     }
 
     @Override
-    void testExtremeValues() {
+    protected void testExtremeValues() {
         // PaginatedStore is not meant to be used with values that are extremely far from one another as it
         // would allocate an excessively large array.
     }
 
     @Override
-    void testMergingExtremeValues() {
+    protected void testMergingExtremeValues() {
         // PaginatedStore is not meant to be used with values that are extremely far from one another as it
         // would allocate an excessively large array.
     }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/SparseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/SparseStoreTest.java
@@ -8,7 +8,7 @@ package com.datadoghq.sketch.ddsketch.store;
 class SparseStoreTest extends ExhaustiveStoreTest {
 
     @Override
-    Store newStore() {
+    protected Store newStore() {
         return new SparseStore();
     }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -22,11 +22,11 @@ import java.util.stream.StreamSupport;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-abstract class StoreTest {
+public abstract class StoreTest {
 
-    abstract Store newStore();
+    protected abstract Store newStore();
 
-    abstract Map<Integer, Double> getCounts(Bin[] bins);
+    protected abstract Map<Integer, Double> getCounts(Store store, Bin[] bins);
 
     private static Map<Integer, Double> getCounts(Stream<Bin> bins) {
         return bins.collect(Collectors.groupingBy(Bin::getIndex, Collectors.summingDouble(Bin::getCount)));
@@ -50,7 +50,7 @@ abstract class StoreTest {
     }
 
     private void test(Bin[] bins, Store store) {
-        final Map<Integer, Double> expectedNonZeroCounts = getNonZeroCounts(getCounts(bins));
+        final Map<Integer, Double> expectedNonZeroCounts = getNonZeroCounts(getCounts(store, bins));
         assertEncodes(expectedNonZeroCounts, store);
         // Test protobuf round-trip
         assertEncodes(expectedNonZeroCounts, Store.fromProto(this::newStore, store.toProto()));
@@ -216,7 +216,7 @@ abstract class StoreTest {
     }
 
     @Test
-    void testExtremeValues() {
+    protected void testExtremeValues() {
         testAdding(Integer.MIN_VALUE);
         testAdding(Integer.MAX_VALUE);
         testAdding(0, Integer.MIN_VALUE);
@@ -262,7 +262,7 @@ abstract class StoreTest {
     }
 
     @Test
-    void testMergingExtremeValues() {
+    protected void testMergingExtremeValues() {
         testMerging(new int[]{ 0 }, new int[]{ Integer.MIN_VALUE });
         testMerging(new int[]{ 0 }, new int[]{ Integer.MAX_VALUE });
         testMerging(new int[]{ Integer.MIN_VALUE }, new int[]{ 0 });

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/UnboundedSizeDenseStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/UnboundedSizeDenseStoreTest.java
@@ -8,18 +8,18 @@ package com.datadoghq.sketch.ddsketch.store;
 class UnboundedSizeDenseStoreTest extends ExhaustiveStoreTest {
 
     @Override
-    Store newStore() {
+    protected Store newStore() {
         return new UnboundedSizeDenseStore();
     }
 
     @Override
-    void testExtremeValues() {
+    protected void testExtremeValues() {
         // UnboundedSizeDenseStore is not meant to be used with values that are extremely far from one another as it
         // would allocate an excessively large array.
     }
 
     @Override
-    void testMergingExtremeValues() {
+    protected void testMergingExtremeValues() {
         // UnboundedSizeDenseStore is not meant to be used with values that are extremely far from one another as it
         // would allocate an excessively large array.
     }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/rescaling/BoundedSizeRescalingStoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/rescaling/BoundedSizeRescalingStoreTest.java
@@ -1,0 +1,73 @@
+package com.datadoghq.sketch.ddsketch.store.rescaling;
+
+import com.datadoghq.sketch.ddsketch.store.Bin;
+import com.datadoghq.sketch.ddsketch.store.Store;
+import com.datadoghq.sketch.ddsketch.store.StoreTest;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class BoundedSizeRescalingStoreTest extends StoreTest {
+
+    abstract int maxNumBins();
+
+    @Override
+    protected Store newStore() {
+        return new BoundedSizeRescalingStore(maxNumBins());
+    }
+
+    @Override
+    protected Map<Integer, Double> getCounts(Store store, Bin... bins) {
+
+        // FIXME: move elsewhere, avoid casting
+        final Store delegate = ((RescalingStore) store).delegate;
+        assertTrue(delegate.isEmpty() || delegate.getMaxIndex() - delegate.getMinIndex() <= maxNumBins());
+
+        final int scalingFactor = store.maxShift() + 1;
+        return Arrays.stream(bins)
+            .map(bin -> new Bin(Math.floorDiv(bin.getIndex(), scalingFactor) * scalingFactor, bin.getCount()))
+            .collect(Collectors.groupingBy(
+                Bin::getIndex,
+                Collectors.summingDouble(Bin::getCount)
+            ));
+    }
+
+    @Override
+    protected void testExtremeValues() {
+        // PaginatedStore is not meant to be used with values that are extremely far from one another as it
+        // would allocate an excessively large array.
+    }
+
+    @Override
+    protected void testMergingExtremeValues() {
+        // PaginatedStore is not meant to be used with values that are extremely far from one another as it
+        // would allocate an excessively large array.
+    }
+
+    static class BoundedSizeRescalingStoreTest1 extends BoundedSizeRescalingStoreTest {
+
+        @Override
+        int maxNumBins() {
+            return 1;
+        }
+    }
+
+    static class BoundedSizeRescalingStoreTest10 extends BoundedSizeRescalingStoreTest {
+
+        @Override
+        int maxNumBins() {
+            return 10;
+        }
+    }
+
+    static class BoundedSizeRescalingStoreTest100 extends BoundedSizeRescalingStoreTest {
+
+        @Override
+        int maxNumBins() {
+            return 100;
+        }
+    }
+}


### PR DESCRIPTION
Hence uniformly degrading the relative accuracy of the sketch that uses it.

See [the javadoc of `BoundedSizeRescalingStore`](https://github.com/DataDog/sketches-java/blob/8a8a7cd832a69fe9a37b388a7647881b19a675aa/src/main/java/com/datadoghq/sketch/ddsketch/store/rescaling/BoundedSizeRescalingStore.java#L8:L17) for details.

This is a POC, still requiring some work.