### PR TITLE
implement inverted iteration for faster iteration without allocation

### DIFF
--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/BuiltSketchState.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/BuiltSketchState.java
@@ -1,0 +1,36 @@
+package com.datadoghq.sketch.ddsketch.benchmarks;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.DDSketchOption;
+import com.datadoghq.sketch.ddsketch.DataGenerator;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public abstract class BuiltSketchState {
+    @Param
+    DataGenerator generator;
+
+    @Param({"NANOSECONDS", "MICROSECONDS", "MILLISECONDS"})
+    TimeUnit unit;
+
+    @Param
+    DDSketchOption sketchOption;
+
+    @Param("100000")
+    int count;
+
+    @Param({"0.01"})
+    double relativeAccuracy;
+
+    DDSketch sketch;
+
+    @Setup(Level.Trial)
+    public void init() {
+        this.sketch = sketchOption.create(relativeAccuracy);
+        for (int i = 0; i < count; ++i) {
+            sketch.accept(unit.toNanos(Math.abs(Math.round(generator.nextValue()))));
+        }
+    }
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Iterate.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Iterate.java
@@ -1,0 +1,34 @@
+package com.datadoghq.sketch.ddsketch.benchmarks;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class Iterate extends BuiltSketchState {
+
+    @Benchmark
+    public void forEach(Blackhole bh) {
+        sketch.getPositiveValueStore().forEach((index, value) -> {
+            bh.consume(index);
+            bh.consume(value);
+        });
+    }
+
+    @Benchmark
+    public void ascendingIterator(Blackhole bh) {
+        sketch.getPositiveValueStore()
+                .getAscendingStream()
+                .forEach(bin -> {
+                    // don't consume the bin to give scalarisaton a chance
+                    // after the lamda is inlined
+                    bh.consume(bin.getIndex());
+                    bh.consume(bin.getCount());
+                });
+    }
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Summaries.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Summaries.java
@@ -1,8 +1,5 @@
 package com.datadoghq.sketch.ddsketch.benchmarks;
 
-import com.datadoghq.sketch.ddsketch.DDSketch;
-import com.datadoghq.sketch.ddsketch.DDSketchOption;
-import com.datadoghq.sketch.ddsketch.DataGenerator;
 import org.openjdk.jmh.annotations.*;
 
 import java.util.concurrent.TimeUnit;
@@ -10,56 +7,10 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @BenchmarkMode(Mode.AverageTime)
-public class Summaries {
-
-    @Param
-    DataGenerator generator;
-
-    @Param({"NANOSECONDS", "MICROSECONDS", "MILLISECONDS"})
-    TimeUnit unit;
-
-    @Param
-    DDSketchOption sketchOption;
-
-    @Param("100000")
-    int count;
-
-    @Param({"0.01"})
-    double relativeAccuracy;
-
-    DDSketch sketch;
-
-    @Setup(Level.Trial)
-    public void init() {
-        this.sketch = sketchOption.create(relativeAccuracy);
-        for (int i = 0; i < count; ++i) {
-            sketch.accept(unit.toNanos(Math.round(generator.nextValue())));
-        }
-    }
+public class Summaries extends BuiltSketchState {
 
     @Benchmark
     public double getCount() {
         return sketch.getCount();
     }
-
-    @Benchmark
-    public double getMax() {
-        return sketch.getMaxValue();
-    }
-
-    @Benchmark
-    public double getMin() {
-        return sketch.getMinValue();
-    }
-
-    @Benchmark
-    public double getMedian() {
-        return sketch.getValueAtQuantile(0.5);
-    }
-
-    @Benchmark
-    public double getP99() {
-        return sketch.getValueAtQuantile(0.99);
-    }
-
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/BinAcceptor.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/BinAcceptor.java
@@ -1,0 +1,6 @@
+package com.datadoghq.sketch.ddsketch.store;
+
+@FunctionalInterface
+public interface BinAcceptor {
+    void accept(int index, double value);
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
@@ -236,6 +236,16 @@ public abstract class DenseStore implements Store {
     }
 
     @Override
+    public void forEach(BinAcceptor acceptor) {
+        for (int i = minIndex; i <= maxIndex; i++) {
+            double value = counts[i-offset];
+            if (value != 0) {
+                acceptor.accept(i, value);
+            }
+        }
+    }
+
+    @Override
     public Stream<Bin> getAscendingStream() {
         if (isEmpty()) {
             return Stream.of();

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
@@ -237,11 +237,18 @@ public abstract class DenseStore implements Store {
 
     @Override
     public void forEach(BinAcceptor acceptor) {
-        for (int i = minIndex; i <= maxIndex; i++) {
-            double value = counts[i-offset];
+        if (isEmpty()) {
+            return;
+        }
+        for (int i = minIndex; i < maxIndex; i++) {
+            double value = counts[i - offset];
             if (value != 0) {
                 acceptor.accept(i, value);
             }
+        }
+        double lastCount = counts[maxIndex - offset];
+        if (lastCount != 0) {
+            acceptor.accept(maxIndex, lastCount);
         }
     }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -83,6 +83,21 @@ public final class PaginatedStore implements Store {
     }
 
     @Override
+    public void forEach(BinAcceptor acceptor) {
+        int base = minPageIndex;
+        for (double[] page : pages) {
+            if (null != page) {
+                for (int i = 0; i < page.length; ++i) {
+                    if (page[i] != 0) {
+                        acceptor.accept(base + i, page[i]);
+                    }
+                }
+            }
+            base += PAGE_SIZE;
+        }
+    }
+
+    @Override
     public double getTotalCount() {
         if (isEmpty()) {
             return 0D;

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -87,16 +87,15 @@ public final class PaginatedStore implements Store {
         if (isEmpty()) {
             return;
         }
-        int base = minPageIndex;
-        for (double[] page : pages) {
+        for (int i = 0; i < pages.length; ++i) {
+            double[] page = pages[i];
             if (null != page) {
-                for (int i = 0; i < page.length; ++i) {
-                    if (page[i] != 0) {
-                        acceptor.accept(base + i, page[i]);
+                for (int j = 0; j < page.length; ++j) {
+                    if (page[j] != 0) {
+                        acceptor.accept(((i + minPageIndex) << PAGE_SHIFT) + j, page[j]);
                     }
                 }
             }
-            base += PAGE_SIZE;
         }
     }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -84,6 +84,9 @@ public final class PaginatedStore implements Store {
 
     @Override
     public void forEach(BinAcceptor acceptor) {
+        if (isEmpty()) {
+            return;
+        }
         int base = minPageIndex;
         for (double[] page : pages) {
             if (null != page) {

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/SparseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/SparseStore.java
@@ -68,6 +68,11 @@ public class SparseStore implements Store {
     }
 
     @Override
+    public void forEach(BinAcceptor acceptor) {
+        bins.forEach(acceptor::accept);
+    }
+
+    @Override
     public Iterator<Bin> getAscendingIterator() {
         return getBinIterator(bins);
     }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
@@ -121,6 +121,12 @@ public interface Store {
     }
 
     /**
+     * Supplies each bin to the acceptor
+     * @param acceptor consumes this store's bins
+     */
+    void forEach(BinAcceptor acceptor);
+
+    /**
      * @return a stream with the non-empty bins of this store as its source
      */
     default Stream<Bin> getStream() {

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
@@ -124,7 +124,9 @@ public interface Store {
      * Supplies each bin to the acceptor
      * @param acceptor consumes this store's bins
      */
-    void forEach(BinAcceptor acceptor);
+    default void forEach(BinAcceptor acceptor) {
+        getStream().forEach(bin -> acceptor.accept(bin.getIndex(), bin.getCount()));
+    }
 
     /**
      * @return a stream with the non-empty bins of this store as its source

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -298,8 +298,10 @@ abstract class StoreTest {
 
     public static Stream<Arguments> intStreams() {
         return Stream.of(
+                new int[0],
                 IntStream.range(0, 10000).toArray(),
                 IntStream.range(0, 10000).map(i -> i % 10).toArray(),
+                IntStream.range(0, 10000).map(i -> i / 10).toArray(),
                 IntStream.range(0, 10000).map(i -> i * 10).toArray()
         ).map(Arguments::of);
     }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -34,6 +34,12 @@ abstract class StoreTest {
         return getCounts(StreamSupport.stream(Spliterators.spliteratorUnknownSize(bins, 0), false));
     }
 
+    private static Map<Integer, Double> getCounts(Store store) {
+        Map<Integer, Double> counts = new TreeMap<>();
+        store.forEach(counts::put);
+        return counts;
+    }
+
     private static Map<Integer, Double> getNonZeroCounts(Map<Integer, Double> counts) {
         return counts.entrySet().stream()
             .filter(entry -> entry.getValue() > 0)
@@ -81,6 +87,7 @@ abstract class StoreTest {
         assertSameCounts(expectedCounts, getCounts(store.getDescendingStream()));
         assertSameCounts(expectedCounts, getCounts(store.getAscendingIterator()));
         assertSameCounts(expectedCounts, getCounts(store.getDescendingIterator()));
+        assertSameCounts(expectedCounts, getCounts(store));
     }
 
     private static Bin[] toBins(int... values) {
@@ -311,10 +318,8 @@ abstract class StoreTest {
     public void testForEach(int[] data) {
         Store store = newStore();
         Arrays.stream(data).forEach(store::add);
-        Map<Integer, Double> expect = new TreeMap<>();
-        Map<Integer, Double> got = new TreeMap<>();
-        store.getAscendingStream().forEach(bin -> expect.put(bin.getIndex(), bin.getCount()));
-        store.forEach(got::put);
+        Map<Integer, Double> expect = getCounts(store);
+        Map<Integer, Double> got = getCounts(store.getAscendingIterator());
         assertEquals(expect, got);
     }
 }


### PR DESCRIPTION
### What does this PR do?

This allows users to iterate over the sketch in a way that's easier for the JIT to optimise, and ends up avoiding the allocation of `Bin` and the iterator objects.

### Motivation

Lower overhead API, I also hope that this will be used for future implementation work.

### Additional Notes

I added a benchmark where I took care _not_ to blackhole the `Bin` which shows both the `Bin` and the underlying `Iterator` really do get allocated, even in the simplest case where the lambda can be shown to inline with `-XX:+PrintInlining`. 

```
java -jar build/libs/sketches-java-0.5.1-SNAPSHOT-jmh.jar -wi 5 -i 5 -w 1 -r 1 -f 1 -p unit=NANOSECONDS -p generator=POISSON -jvmArgsPrepend "-XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining"   Iterate.ascendingIterator
```

```
                                @ 4   com.datadoghq.sketch.ddsketch.DDSketch::getPositiveValueStore (5 bytes)   accessor
                                @ 7   com.datadoghq.sketch.ddsketch.store.DenseStore::getAscendingStream (49 bytes)   already compiled into a big method
                                 \-> TypeProfile (126031/126031 counts) = com/datadoghq/sketch/ddsketch/store/UnboundedSizeDenseStore
                                @ 13   java.lang.invoke.Invokers$Holder::linkToTargetMethod (9 bytes)   force inline by annotation
                                  @ 5   java.lang.invoke.DirectMethodHandle$Holder::invokeStatic (14 bytes)   force inline by annotation
                                    @ 1   java.lang.invoke.DirectMethodHandle::internalMemberName (8 bytes)   force inline by annotation
                                    @ 10   com.datadoghq.sketch.ddsketch.benchmarks.Iterate$$Lambda$42/0x0000000840091840::get$Lambda (9 bytes)   inline (hot)
                                      @ 5   com.datadoghq.sketch.ddsketch.benchmarks.Iterate$$Lambda$42/0x0000000840091840::<init> (10 bytes)   inline (hot)
                                        @ 1   java.lang.Object::<init> (1 bytes)   inline (hot)
```


```
sudo taskset -c 0 java -jar build/libs/sketches-java-0.5.1-SNAPSHOT-jmh.jar -wi 5 -i 5 -w 1 -r 1 -f 1 -p unit=NANOSECONDS -p generator=POISSON  -prof gc Iterate
```

Here you can see that normalised allocation rates are much lower. Where it's 16B/invocation for the inverted iteration, this is due to the lambda capturing the `Blackhole`.

```
Benchmark                                                (count)  (generator)  (relativeAccuracy)  (sketchOption)       (unit)  Mode  Cnt     Score     Error   Units
Iterate.ascendingIterator                                 100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     2.543 ±   0.096   us/op
Iterate.ascendingIterator:·gc.alloc.rate                  100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5    81.410 ±   3.254  MB/sec
Iterate.ascendingIterator:·gc.alloc.rate.norm             100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5   328.001 ±   0.001    B/op
Iterate.ascendingIterator:·gc.churn.Eden_Space            100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5    79.447 ±  76.267  MB/sec
Iterate.ascendingIterator:·gc.churn.Eden_Space.norm       100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5   320.271 ± 309.491    B/op
Iterate.ascendingIterator:·gc.churn.Survivor_Space        100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     0.284 ±   2.352  MB/sec
Iterate.ascendingIterator:·gc.churn.Survivor_Space.norm   100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     1.161 ±   9.641    B/op
Iterate.ascendingIterator:·gc.count                       100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     9.000            counts
Iterate.ascendingIterator:·gc.time                        100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5    30.000                ms
Iterate.ascendingIterator                                 100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     2.314 ±   0.178   us/op
Iterate.ascendingIterator:·gc.alloc.rate                  100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5   665.569 ±  52.049  MB/sec
Iterate.ascendingIterator:·gc.alloc.rate.norm             100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5  2440.001 ±   0.001    B/op
Iterate.ascendingIterator:·gc.churn.Eden_Space            100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5   670.580 ± 141.871  MB/sec
Iterate.ascendingIterator:·gc.churn.Eden_Space.norm       100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5  2457.165 ± 353.919    B/op
Iterate.ascendingIterator:·gc.churn.Survivor_Space        100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     0.003 ±   0.012  MB/sec
Iterate.ascendingIterator:·gc.churn.Survivor_Space.norm   100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     0.011 ±   0.042    B/op
Iterate.ascendingIterator:·gc.count                       100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5    76.000            counts
Iterate.ascendingIterator:·gc.time                        100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5    14.000                ms
Iterate.ascendingIterator                                 100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     1.795 ±   0.046   us/op
Iterate.ascendingIterator:·gc.alloc.rate                  100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5   115.162 ±   3.806  MB/sec
Iterate.ascendingIterator:·gc.alloc.rate.norm             100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5   328.001 ±   0.001    B/op
Iterate.ascendingIterator:·gc.churn.Eden_Space            100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5   114.570 ±  93.241  MB/sec
Iterate.ascendingIterator:·gc.churn.Eden_Space.norm       100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5   326.415 ± 267.515    B/op
Iterate.ascendingIterator:·gc.churn.Survivor_Space        100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     0.284 ±   2.373  MB/sec
Iterate.ascendingIterator:·gc.churn.Survivor_Space.norm   100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     0.810 ±   6.762    B/op
Iterate.ascendingIterator:·gc.count                       100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5    13.000            counts
Iterate.ascendingIterator:·gc.time                        100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5    15.000                ms
Iterate.ascendingIterator                                 100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5     1.475 ±   0.027   us/op
Iterate.ascendingIterator:·gc.alloc.rate                  100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5    65.055 ±   1.787  MB/sec
Iterate.ascendingIterator:·gc.alloc.rate.norm             100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5   152.001 ±   0.001    B/op
Iterate.ascendingIterator:·gc.churn.Eden_Space            100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5    61.852 ±  93.653  MB/sec
Iterate.ascendingIterator:·gc.churn.Eden_Space.norm       100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5   144.569 ± 219.533    B/op
Iterate.ascendingIterator:·gc.count                       100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5     7.000            counts
Iterate.ascendingIterator:·gc.time                        100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5    19.000                ms
Iterate.forEach                                           100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     1.931 ±   0.153   us/op
Iterate.forEach:·gc.alloc.rate                            100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     5.251 ±   0.417  MB/sec
Iterate.forEach:·gc.alloc.rate.norm                       100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5    16.001 ±   0.001    B/op
Iterate.forEach:·gc.churn.Eden_Space                      100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     8.851 ±  76.212  MB/sec
Iterate.forEach:·gc.churn.Eden_Space.norm                 100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5    27.967 ± 240.802    B/op
Iterate.forEach:·gc.count                                 100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     1.000            counts
Iterate.forEach:·gc.time                                  100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     4.000                ms
Iterate.forEach                                           100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     1.184 ±   0.012   us/op
Iterate.forEach:·gc.alloc.rate                            100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     8.564 ±   0.122  MB/sec
Iterate.forEach:·gc.alloc.rate.norm                       100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5    16.000 ±   0.001    B/op
Iterate.forEach:·gc.churn.Eden_Space                      100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     8.844 ±  76.153  MB/sec
Iterate.forEach:·gc.churn.Eden_Space.norm                 100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5    16.593 ± 142.871    B/op
Iterate.forEach:·gc.count                                 100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     1.000            counts
Iterate.forEach:·gc.time                                  100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     3.000                ms
Iterate.forEach                                           100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     1.191 ±   0.011   us/op
Iterate.forEach:·gc.alloc.rate                            100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     8.510 ±   0.106  MB/sec
Iterate.forEach:·gc.alloc.rate.norm                       100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5    16.000 ±   0.001    B/op
Iterate.forEach:·gc.churn.Eden_Space                      100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     8.848 ±  76.188  MB/sec
Iterate.forEach:·gc.churn.Eden_Space.norm                 100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5    16.727 ± 144.026    B/op
Iterate.forEach:·gc.count                                 100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     1.000            counts
Iterate.forEach:·gc.time                                  100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     3.000                ms
Iterate.forEach                                           100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5     1.369 ±   0.541   us/op
Iterate.forEach:·gc.alloc.rate                            100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5    ≈ 10⁻⁴            MB/sec
Iterate.forEach:·gc.alloc.rate.norm                       100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5     0.001 ±   0.001    B/op
Iterate.forEach:·gc.count                                 100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5       ≈ 0            counts

```

Filtering for times only:


```
Benchmark                                                (count)  (generator)  (relativeAccuracy)  (sketchOption)       (unit)  Mode  Cnt     Score     Error   Units
  Iterate.ascendingIterator                                 100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     2.543 ±   0.096   us/op
  Iterate.ascendingIterator                                 100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     2.314 ±   0.178   us/op
  Iterate.ascendingIterator                                 100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     1.795 ±   0.046   us/op
  Iterate.ascendingIterator                                 100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5     1.475 ±   0.027   us/op
  Iterate.forEach                                           100000      POISSON                0.01            FAST  NANOSECONDS  avgt    5     1.931 ±   0.153   us/op
  Iterate.forEach                                           100000      POISSON                0.01  MEMORY_OPTIMAL  NANOSECONDS  avgt    5     1.184 ±   0.012   us/op
  Iterate.forEach                                           100000      POISSON                0.01        BALANCED  NANOSECONDS  avgt    5     1.191 ±   0.011   us/op
  Iterate.forEach                                           100000      POISSON                0.01       PAGINATED  NANOSECONDS  avgt    5     1.369 ±   0.541   us/op
```
