### PR TITLE
prefer Store.forEach to Store.getStream().forEach

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -193,7 +193,7 @@ public final class PaginatedStore implements Store {
         if (store instanceof PaginatedStore) {
             mergeWith((PaginatedStore) store);
         } else {
-            store.getStream().forEach(this::add);
+            store.forEach(this::add);
         }
     }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
@@ -63,7 +63,7 @@ public interface Store {
      * @param store the store to be merged into this one
      */
     default void mergeWith(Store store) {
-        store.getStream().forEach(this::add);
+        store.forEach(this::add);
     }
 
     /**
@@ -170,7 +170,7 @@ public interface Store {
         final com.datadoghq.sketch.ddsketch.proto.Store.Builder storeBuilder =
             com.datadoghq.sketch.ddsketch.proto.Store.newBuilder();
         // In the general case, we use the sparse representation to encode bin counts.
-        getStream().forEach(bin -> storeBuilder.putBinCounts(bin.getIndex(), bin.getCount()));
+        forEach(storeBuilder::putBinCounts);
         return storeBuilder.build();
     }
 


### PR DESCRIPTION
Just replaces the default implementations using `store.getStream().forEach(...)` with `store.forEach(...)` which improves the default `Store::toProto` method somewhat.
