### PR TITLE
Add quantile sketch wrapper that keeps track of exact sum, min and max

### DIFF
--- a/src/main/java/com/datadoghq/sketch/WithExactSummaryStatistics.java
+++ b/src/main/java/com/datadoghq/sketch/WithExactSummaryStatistics.java
@@ -1,0 +1,166 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch;
+
+import java.util.NoSuchElementException;
+import java.util.function.Supplier;
+
+/**
+ * A wrapper that returns exact count, sum, average, minimum and maximum, and relies on the provided
+ * {@link QuantileSketch} to keep track of quantiles.
+ *
+ * @param <QS> the type of the wrapped sketch that is used to compute quantiles
+ */
+public class WithExactSummaryStatistics<QS extends QuantileSketch<QS>>
+    implements QuantileSketch<WithExactSummaryStatistics<QS>> {
+
+  private final QS sketch;
+  private double count;
+  private double sum;
+  // Similar to DoubleSummaryStatistics
+  private double sumCompensation; // Low order bits of sum
+  private double simpleSum; // Used to compute right sum for non-finite inputs
+  private double min;
+  private double max;
+
+  public WithExactSummaryStatistics(Supplier<QS> sketchSupplier) {
+    this.sketch = sketchSupplier.get();
+    this.count = 0;
+    this.sum = 0;
+    this.sumCompensation = 0;
+    this.simpleSum = 0;
+    this.min = Double.POSITIVE_INFINITY;
+    this.max = Double.NEGATIVE_INFINITY;
+  }
+
+  private WithExactSummaryStatistics(
+      QS sketch,
+      double count,
+      double sum,
+      double sumCompensation,
+      double simpleSum,
+      double min,
+      double max) {
+    this.sketch = sketch;
+    this.count = count;
+    this.sum = sum;
+    this.sumCompensation = sumCompensation;
+    this.simpleSum = simpleSum;
+    this.min = min;
+    this.max = max;
+  }
+
+  @Override
+  public void accept(double value) {
+    sketch.accept(value);
+    count++;
+    simpleSum += value;
+    sumWithCompensation(value);
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+  }
+
+  @Override
+  public void accept(double value, double count) {
+    sketch.accept(value, count);
+    this.count += count;
+    simpleSum += value * count;
+    sumWithCompensation(value * count);
+    min = Math.min(min, value);
+    max = Math.max(max, value);
+  }
+
+  @Override
+  public void mergeWith(WithExactSummaryStatistics<QS> other) {
+    sketch.mergeWith(other.sketch);
+    count += other.count;
+    simpleSum += other.simpleSum;
+    sumWithCompensation(other.sum);
+    sumWithCompensation(other.sumCompensation);
+    min = Math.min(min, other.min);
+    max = Math.max(max, other.max);
+  }
+
+  private void sumWithCompensation(double value) {
+    final double tmp = value - sumCompensation;
+    final double velvel = sum + tmp; // Little wolf of rounding error
+    sumCompensation = (velvel - sum) - tmp;
+    sum = velvel;
+  }
+
+  @Override
+  public WithExactSummaryStatistics<QS> copy() {
+    return new WithExactSummaryStatistics<>(
+        sketch.copy(), count, sum, sumCompensation, simpleSum, min, max);
+  }
+
+  @Override
+  public void clear() {
+    sketch.clear();
+    count = 0;
+    sum = 0;
+    sumCompensation = 0;
+    simpleSum = 0;
+    min = Double.POSITIVE_INFINITY;
+    max = Double.NEGATIVE_INFINITY;
+  }
+
+  @Override
+  public double getCount() {
+    return count;
+  }
+
+  @Override
+  public double getSum() {
+    // Better error bounds to add both terms as the final sum
+    final double tmp = sum + sumCompensation;
+    if (Double.isNaN(tmp) && Double.isInfinite(simpleSum)) {
+      // If the compensated sum is spuriously NaN from accumulating one or more same-signed infinite
+      // values, return the correctly-signed infinity stored in simpleSum.
+      return simpleSum;
+    } else {
+      return tmp;
+    }
+  }
+
+  @Override
+  public double getMinValue() {
+    if (count == 0) {
+      throw new NoSuchElementException();
+    }
+    return min;
+  }
+
+  @Override
+  public double getMaxValue() {
+    if (count == 0) {
+      throw new NoSuchElementException();
+    }
+    return max;
+  }
+
+  @Override
+  public double getValueAtQuantile(double quantile) {
+    return clamp(sketch.getValueAtQuantile(quantile));
+  }
+
+  @Override
+  public double[] getValuesAtQuantiles(double[] quantiles) {
+    final double[] valuesAtQuantiles = sketch.getValuesAtQuantiles(quantiles);
+    for (int i = 0; i < valuesAtQuantiles.length; i++) {
+      valuesAtQuantiles[i] = clamp(valuesAtQuantiles[i]);
+    }
+    return valuesAtQuantiles;
+  }
+
+  private double clamp(double value) {
+    if (max < min) {
+      // Only if the sketch is empty, in which case this method should not be called.
+      throw new IllegalStateException();
+    }
+    return Math.max(Math.min(value, max), min);
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/WithExactSummaryStatistics.java
+++ b/src/main/java/com/datadoghq/sketch/WithExactSummaryStatistics.java
@@ -21,6 +21,8 @@ public class WithExactSummaryStatistics<QS extends QuantileSketch<QS>>
   private double count;
   private double sum;
   // Similar to DoubleSummaryStatistics
+  // We use a compensated sum to avoid accumulating rounding errors.
+  // See https://en.wikipedia.org/wiki/Kahan_summation_algorithm.
   private double sumCompensation; // Low order bits of sum
   private double simpleSum; // Used to compute right sum for non-finite inputs
   private double min;

--- a/src/test/java/com/datadoghq/sketch/WithExactSummaryStatisticsTest.java
+++ b/src/test/java/com/datadoghq/sketch/WithExactSummaryStatisticsTest.java
@@ -1,0 +1,144 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.DoubleSummaryStatistics;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.Assertions;
+
+public class WithExactSummaryStatisticsTest
+    extends QuantileSketchTest<
+        WithExactSummaryStatistics<WithExactSummaryStatisticsTest.DummySketch>> {
+
+  static class DummySketch implements QuantileSketch<DummySketch> {
+
+    private double count;
+
+    private DummySketch() {
+      this.count = 0;
+    }
+
+    private DummySketch(double count) {
+      this.count = count;
+    }
+
+    @Override
+    public void accept(double value) {
+      count++;
+    }
+
+    @Override
+    public void accept(double value, double count) {
+      if (count < 0) {
+        throw new IllegalArgumentException();
+      }
+      this.count += count;
+    }
+
+    @Override
+    public void mergeWith(DummySketch other) {
+      this.count += other.count;
+    }
+
+    @Override
+    public DummySketch copy() {
+      return new DummySketch(count);
+    }
+
+    @Override
+    public void clear() {
+      count = 0;
+    }
+
+    @Override
+    public double getCount() {
+      // This method should not be relied upon.
+      Assertions.fail();
+      return 0;
+    }
+
+    @Override
+    public double getSum() {
+      // This method should not be relied upon.
+      Assertions.fail();
+      return 0;
+    }
+
+    @Override
+    public double getMinValue() {
+      // This method should not be relied upon.
+      Assertions.fail();
+      return 0;
+    }
+
+    @Override
+    public double getMaxValue() {
+      // This method should not be relied upon.
+      Assertions.fail();
+      return 0;
+    }
+
+    @Override
+    public double getValueAtQuantile(double quantile) {
+      if (quantile < 0 || quantile > 1) {
+        throw new IllegalArgumentException();
+      }
+      if (count == 0) {
+        throw new NoSuchElementException();
+      }
+      return 0;
+    }
+
+    @Override
+    public double[] getValuesAtQuantiles(double[] quantiles) {
+      if (Arrays.stream(quantiles).anyMatch(quantile -> quantile < 0 || quantile > 1)) {
+        throw new IllegalArgumentException();
+      }
+      if (count == 0) {
+        throw new NoSuchElementException();
+      }
+      return new double[] {0};
+    }
+  }
+
+  @Override
+  protected WithExactSummaryStatistics<DummySketch> newSketch() {
+    return new WithExactSummaryStatistics<>(DummySketch::new);
+  }
+
+  @Override
+  protected void assertQuantileAccurate(
+      boolean merged, double[] sortedValues, double quantile, double actualQuantileValue) {
+    // Nothing to assert
+  }
+
+  @Override
+  protected void assertMinAccurate(double[] sortedValues, double actualMinValue) {
+    assertEquals(sortedValues[0], actualMinValue);
+  }
+
+  @Override
+  protected void assertMaxAccurate(double[] sortedValues, double actualMaxValue) {
+    assertEquals(sortedValues[sortedValues.length - 1], actualMaxValue);
+  }
+
+  @Override
+  protected void assertSumAccurate(double[] sortedValues, double actualSumValue) {
+    final DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
+    Arrays.stream(sortedValues).forEach(summaryStatistics);
+    assertEquals(summaryStatistics.getSum(), actualSumValue);
+  }
+
+  @Override
+  protected void assertAverageAccurate(double[] sortedValues, double actualAverageValue) {
+    final DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
+    Arrays.stream(sortedValues).forEach(summaryStatistics);
+    assertEquals(summaryStatistics.getAverage(), actualAverageValue);
+  }
+}


### PR DESCRIPTION
DDSketch does not keep track of the exact sum, min and max (which makes the insertion operation slightly more performant). In instances where we want to track them exactly, `WithExactSummaryStatistics` can be used.