### PR TITLE
Add an index mapping with quartic interpolation

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -13,7 +13,7 @@ import static com.datadoghq.sketch.ddsketch.mapping.Interpolation.CUBIC;
  * representations of floating-point values and cubically interpolating the logarithm in-between.
  *
  * <p>Calculating the bucket index with this mapping is much faster than computing the logarithm of
- * the value (by a factor of 3 according to some benchmarks, although it depends on various
+ * the value (by a factor of 6 according to some benchmarks, although it depends on various
  * factors), and this mapping incurs a memory usage overhead of only 1% compared to the
  * memory-optimal {@link LogarithmicMapping}, under the relative accuracy condition. In comparison,
  * the overheads for {@link LinearlyInterpolatedMapping} and {@link

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
@@ -31,33 +31,33 @@ import com.datadoghq.sketch.ddsketch.Serializer;
  * </tr>
  * <tr>
  * <td>{@link LogarithmicMapping}</td>
- * <td>0% (optimal)</td>
- * <td>0% (optimal)</td>
- * <td>100% (reference)</td>
+ * <td>\(0\%\) (optimal)</td>
+ * <td>\(0\%\) (optimal)</td>
+ * <td>\(100\%\) (reference)</td>
  * </tr>
  * <tr>
  * <td>{@link CubicallyInterpolatedMapping}</td>
- * <td>~1% ({@code 7/(10*log(2))-1})</td>
- * <td>~1% ({@code 7/(10*log(2))-1})</td>
- * <td>~30%</td>
+ * <td>\(\frac{7}{10\log2}-1 \approx 1.0\%\)</td>
+ * <td>\(\frac{7}{10\log2}-1 \approx 1.0\%\)</td>
+ * <td>\(\sim 30\%\)</td>
  * </tr>
  * <tr>
  * <td>{@link QuadraticallyInterpolatedMapping}</td>
- * <td>~8% ({@code 3/(4*log(2))-1})</td>
- * <td>~8% ({@code 3/(4*log(2))-1})</td>
- * <td>~25%</td>
+ * <td>\(\frac{3}{4\log2}-1 \approx 8.2\%\)</td>
+ * <td>\(\frac{3}{4\log2}-1 \approx 8.2\%\)</td>
+ * <td>\(\sim 25\%\)</td>
  * </tr>
  * <tr>
  * <td>{@link LinearlyInterpolatedMapping}</td>
- * <td>~44% ({@code 1/log(2)-1})</td>
- * <td>~44% ({@code 1/log(2)-1})</td>
- * <td>~20%</td>
+ * <td>\(\frac{1}{\log2}-1 \approx 44\%\)</td>
+ * <td>\(\frac{1}{\log2}-1 \approx 44\%\)</td>
+ * <td>\(\sim 20\%\)</td>
  * </tr>
  * <tr>
  * <td>{@link BitwiseLinearlyInterpolatedMapping}</td>
- * <td>~44% ({@code 1/log(2)-1})</td>
- * <td>~189% ({@code 2/log(2)-1})</td>
- * <td>~15%</td>
+ * <td>\(\frac{1}{\log2}-1 \approx 44\%\)</td>
+ * <td>\(\frac{2}{\log2}-1 \approx 189\%\)</td>
+ * <td>\(\sim 15\%\)</td>
  * </tr>
  * <caption>Comparison of various implementations of {@code IndexMapping}</caption>
  * </table>

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
@@ -36,28 +36,34 @@ import com.datadoghq.sketch.ddsketch.Serializer;
  * <td>\(100\%\) (reference)</td>
  * </tr>
  * <tr>
+ * <td>{@link QuarticallyInterpolatedMapping}</td>
+ * <td>\(\frac{25}{36\log2}-1 \approx 0.19\%\)</td>
+ * <td>\(\frac{25}{36\log2}-1 \approx 0.19\%\)</td>
+ * <td>\(\sim 19\%\)</td>
+ * </tr>
+ * <tr>
  * <td>{@link CubicallyInterpolatedMapping}</td>
  * <td>\(\frac{7}{10\log2}-1 \approx 1.0\%\)</td>
  * <td>\(\frac{7}{10\log2}-1 \approx 1.0\%\)</td>
- * <td>\(\sim 30\%\)</td>
+ * <td>\(\sim 16\%\)</td>
  * </tr>
  * <tr>
  * <td>{@link QuadraticallyInterpolatedMapping}</td>
  * <td>\(\frac{3}{4\log2}-1 \approx 8.2\%\)</td>
  * <td>\(\frac{3}{4\log2}-1 \approx 8.2\%\)</td>
- * <td>\(\sim 25\%\)</td>
+ * <td>\(\sim 14\%\)</td>
  * </tr>
  * <tr>
  * <td>{@link LinearlyInterpolatedMapping}</td>
  * <td>\(\frac{1}{\log2}-1 \approx 44\%\)</td>
  * <td>\(\frac{1}{\log2}-1 \approx 44\%\)</td>
- * <td>\(\sim 20\%\)</td>
+ * <td>\(\sim 12\%\)</td>
  * </tr>
  * <tr>
  * <td>{@link BitwiseLinearlyInterpolatedMapping}</td>
  * <td>\(\frac{1}{\log2}-1 \approx 44\%\)</td>
  * <td>\(\frac{2}{\log2}-1 \approx 189\%\)</td>
- * <td>\(\sim 15\%\)</td>
+ * <td>\(\sim 7\%\)</td>
  * </tr>
  * <caption>Comparison of various implementations of {@code IndexMapping}</caption>
  * </table>

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
@@ -69,10 +69,11 @@ import com.datadoghq.sketch.ddsketch.Serializer;
  * </table>
  *
  * <p>{@link CubicallyInterpolatedMapping}, which uses a polynomial of degree 3 to approximate the
- * logarithm is a good compromise as its memory overhead compared to the optimal logarithmic mapping
- * is only 1%, and it is about 3 times faster than the logarithmic mapping. Using a polynomial of
- * higher degree would not yield a significant gain in memory efficiency (less than 1%), while it
- * would degrade its insertion speed to some extent.
+ * logarithm, usually is a good compromise as its memory overhead compared to the optimal
+ * logarithmic mapping is only 1%, and it is about 6 times faster than the logarithmic mapping.
+ * Using a polynomial of higher degree (e.g., {@link QuarticallyInterpolatedMapping}) does not yield
+ * a significant gain in memory space efficiency (less than 1%), while it degrades its insertion
+ * speed to some extent.
  */
 public interface IndexMapping {
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/Interpolation.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/Interpolation.java
@@ -9,5 +9,6 @@ public enum Interpolation {
   NONE,
   LINEAR,
   QUADRATIC,
-  CUBIC
+  CUBIC,
+  QUARTIC
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
@@ -1,0 +1,76 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.mapping;
+
+/**
+ * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link
+ * LogarithmicMapping}) by extracting the floor value of the logarithm to the base 2 from the binary
+ * representations of floating-point values and quartically interpolating the logarithm in-between.
+ *
+ * <p>The optimal polynomial coefficients can be calculated using the method described in {@link
+ * CubicallyInterpolatedMapping}.
+ */
+public class QuarticallyInterpolatedMapping extends LogLikeIndexMapping {
+
+  private static final double A = -2.0 / 25.0;
+  private static final double B = 8.0 / 25.0;
+  private static final double C = -17.0 / 25.0;
+  private static final double D = 36.0 / 25.0;
+
+  public QuarticallyInterpolatedMapping(double relativeAccuracy) {
+    super(relativeAccuracy);
+  }
+
+  /** {@inheritDoc} */
+  QuarticallyInterpolatedMapping(double gamma, double indexOffset) {
+    super(gamma, indexOffset);
+  }
+
+  @Override
+  double log(double value) {
+    final long longBits = Double.doubleToRawLongBits(value);
+    final double s = DoubleBitOperationHelper.getSignificandPlusOne(longBits) - 1;
+    final double e = (double) DoubleBitOperationHelper.getExponent(longBits);
+    return (((A * s + B) * s + C) * s + D) * s + e;
+  }
+
+  @Override
+  double logInverse(double index) {
+    final double exponent = Math.floor(index);
+    final double e = exponent - index;
+    // Derived from Ferrari's method
+    final double alpha = -(3 * B * B) / (8 * A * A) + C / A; // 2.5
+    final double beta = (B * B * B) / (8 * A * A * A) - (B * C) / (2 * A * A) + D / A; // -9.0
+    final double gamma =
+        -(3 * B * B * B * B) / (256 * A * A * A * A)
+            + (C * B * B) / (16 * A * A * A)
+            - (B * D) / (4 * A * A)
+            + e / A;
+    final double p = -(alpha * alpha) / 12 - gamma;
+    final double q = -(alpha * alpha * alpha) / 108 + (alpha * gamma) / 3 - (beta * beta) / 8;
+    final double r = -q / 2 + Math.sqrt((q * q) / 4 + (p * p * p) / 27);
+    final double u = Math.cbrt(r);
+    final double y = -(5 * alpha) / 6 + u - p / (3 * u);
+    final double w = Math.sqrt(alpha + 2 * y);
+    final double x = -B / (4 * A) + (w - Math.sqrt(-(3 * alpha + 2 * y + (2 * beta) / w))) / 2;
+    return DoubleBitOperationHelper.buildDouble((long) exponent, x + 1);
+  }
+
+  @Override
+  double base() {
+    return 2;
+  }
+
+  @Override
+  double correctingFactor() {
+    return 25 / (36 * Math.log(2));
+  }
+
+  @Override
+  Interpolation interpolation() {
+    return Interpolation.QUARTIC;
+  }
+}

--- a/src/protobuf/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingProtoBinding.java
+++ b/src/protobuf/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingProtoBinding.java
@@ -49,6 +49,8 @@ public class IndexMappingProtoBinding {
         return new QuadraticallyInterpolatedMapping(gamma, indexOffset);
       case CUBIC:
         return new CubicallyInterpolatedMapping(gamma, indexOffset);
+      case QUARTIC:
+        return new QuarticallyInterpolatedMapping(gamma, indexOffset);
       default:
         throw new IllegalArgumentException("unrecognized interpolation");
     }
@@ -64,6 +66,8 @@ public class IndexMappingProtoBinding {
         return IndexMapping.Interpolation.QUADRATIC;
       case CUBIC:
         return IndexMapping.Interpolation.CUBIC;
+      case QUARTIC:
+        return IndexMapping.Interpolation.QUARTIC;
       default:
         throw new IllegalArgumentException("unrecognized interpolation");
     }

--- a/src/protobuf/proto/DDSketch.proto
+++ b/src/protobuf/proto/DDSketch.proto
@@ -48,6 +48,7 @@ message IndexMapping {
     LINEAR = 1;
     QUADRATIC = 2;
     CUBIC = 3;
+    QUARTIC = 4;
   }
 }
 

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/ProtoTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/ProtoTest.java
@@ -55,6 +55,14 @@ class ProtoTest {
                     com.datadoghq.sketch.ddsketch.proto.IndexMapping.Interpolation.CUBIC)
                 .build()),
         Arguments.of(
+            new QuarticallyInterpolatedMapping(1.01, 2),
+            com.datadoghq.sketch.ddsketch.proto.IndexMapping.newBuilder()
+                .setGamma(1.01)
+                .setIndexOffset(2)
+                .setInterpolation(
+                    com.datadoghq.sketch.ddsketch.proto.IndexMapping.Interpolation.QUARTIC)
+                .build()),
+        Arguments.of(
             new BitwiseLinearlyInterpolatedMapping(1e-2),
             com.datadoghq.sketch.ddsketch.proto.IndexMapping.newBuilder()
                 .setGamma(Math.pow(2, 1.0 / (1 << 6)))

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMappingTest.java
@@ -1,0 +1,19 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.mapping;
+
+class QuarticallyInterpolatedMappingTest extends LogLikeIndexMappingTest {
+
+  @Override
+  QuarticallyInterpolatedMapping getMapping(double relativeAccuracy) {
+    return new QuarticallyInterpolatedMapping(relativeAccuracy);
+  }
+
+  @Override
+  QuarticallyInterpolatedMapping getMapping(double gamma, double indexOffset) {
+    return new QuarticallyInterpolatedMapping(gamma, indexOffset);
+  }
+}


### PR DESCRIPTION
This adds a mapping that quartically interpolates between powers of 2, similarly to what `LinearlyInterpolatedMapping`, `QuadraticallyInterpolatedMapping` and `CubicallyInterpolatedMapping` do.

The memory footprint overhead for this mapping is 0.2%, as opposed to 1% for the one that cubically interpolates, while the index computation is slightly more expensive (one more addition and one more multiplication). I don't think this has any significant advantage in practice over the cubic one, but I was curious to see how far we could go. I don't think we can go any further because of the [Abel–Ruffini theorem](https://en.wikipedia.org/wiki/Abel%E2%80%93Ruffini_theorem) (we'd need to solve a quintic equation in `logInverse`).