### PR TITLE
change page size to 32

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -23,7 +23,7 @@ import java.util.NoSuchElementException;
 public final class PaginatedStore implements Store {
 
   private static final int GROWTH = 8;
-  private static final int PAGE_SIZE = 128;
+  private static final int PAGE_SIZE = 32;
   private static final int PAGE_MASK = PAGE_SIZE - 1;
   private static final int PAGE_SHIFT = Integer.bitCount(PAGE_MASK);
 


### PR DESCRIPTION
As discussed, the page size, which was chosen based on C2's autovectorisation threshold for merge speed, is currently too big to be useful, this reduces it to 32.
