### PR TITLE
Add methods for converting sketches and bins across index mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,9 @@ java {
 dependencies {
     protobufImplementation 'com.google.protobuf:protobuf-java:3.13.0'
     testImplementation 'com.google.protobuf:protobuf-java:3.13.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
     testImplementation 'org.openjdk.jol:jol-core:0.10'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'org.openjdk.jol:jol-core:0.10'
 }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
@@ -70,10 +70,19 @@ public class BitwiseLinearlyInterpolatedMapping implements IndexMapping {
 
   @Override
   public double value(int index) {
+    return lowerBound(index) * (1 + relativeAccuracy);
+  }
+
+  @Override
+  public double lowerBound(int index) {
     final int exponent = Math.floorDiv(index, multiplier);
     return DoubleBitOperationHelper.buildDouble(
-            exponent, 1 - exponent + (double) index / multiplier)
-        * (1 + relativeAccuracy);
+        exponent, 1 - exponent + (double) index / multiplier);
+  }
+
+  @Override
+  public double upperBound(int index) {
+    return lowerBound(index + 1);
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
@@ -32,7 +32,7 @@ public class BitwiseLinearlyInterpolatedMapping implements IndexMapping {
     this(getMinNumSignificantBinaryDigits(relativeAccuracy));
   }
 
-  private BitwiseLinearlyInterpolatedMapping(int numSignificantBinaryDigits) {
+  BitwiseLinearlyInterpolatedMapping(int numSignificantBinaryDigits) {
     if (numSignificantBinaryDigits < 0) {
       throw new IllegalArgumentException(
           "The number of significant binary digits cannot be negative.");

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
@@ -8,11 +8,25 @@ package com.datadoghq.sketch.ddsketch.mapping;
 import com.datadoghq.sketch.ddsketch.Serializer;
 
 /**
- * A mapping between {@code double} values and {@code int} values that imposes relative guarantees
- * on the composition of {@link #value} and {@link #index}. Specifically, for any value {@code v}
- * between {@link #minIndexableValue()} and {@link #maxIndexableValue()}, implementations of {@link
- * IndexMapping} must be such that {@code value(index(v))} is close to {@code v} with a relative
- * error that is less than {@link #relativeAccuracy()}.
+ * A mapping between {@code double} positive values and {@code int} values that imposes relative
+ * guarantees on the composition of {@link #value} and {@link #index}. Specifically, for any value
+ * {@code v} between {@link #minIndexableValue()} and {@link #maxIndexableValue()}, implementations
+ * of {@link IndexMapping} must be such that {@code value(index(v))} is close to {@code v} with a
+ * relative error that is less than {@link #relativeAccuracy()}.
+ *
+ * <p>In addition, {@link #index} is required to be increasing, and mappings provide additional
+ * methods {@link #lowerBound} and {@link #upperBound} that are such that for any valid {@code
+ * index},
+ *
+ * <ul>
+ *   <li>{@code lowerBound(index) <= value(index) <= upperBound(index)},
+ *   <li>{@code lowerBound(index + 1) == upperBound(index)} if {@code index + 1} is a valid index,
+ *   <li>if {@code value} is such that {@code lowerBound(index) < value < upperBound(index)}, then
+ *       {@code index(value) == index}.
+ * </ul>
+ *
+ * In other words, an {@code IndexMapping} defines indexed contiguous buckets whose bounds are
+ * provided by {@link #lowerBound} and {@link #upperBound}.
  *
  * <p>In implementations of {@code IndexMapping}, there generally is a trade-off between the cost of
  * computing the index and the number of indices that are required to cover a given range of values
@@ -80,6 +94,10 @@ public interface IndexMapping {
   int index(double value);
 
   double value(int index);
+
+  double lowerBound(int index);
+
+  double upperBound(int index);
 
   double relativeAccuracy();
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
@@ -43,10 +43,21 @@ public interface IndexMappingConverter {
    * initial bins are not themselves resulting from a conversion (in which case \(\alpha_i\) needs
    * to be adjusted to be the effective relative accuracy of the initial bins), the effective
    * relative accuracy of the quantiles that are computed from the bins that result from this
-   * conversion method is upper-bounded by \(\alpha = \frac{\gamma-1}{\gamma+1}\) where \(\gamma =
-   * \gamma_i^2\gamma_o\), \(\gamma_i = \frac{1+\alpha_i}{1-\alpha_i}\), and \(\gamma_o =
-   * \frac{1+\alpha_o}{1-\alpha_o}\). If relative accuracies are small, this is approximately
-   * \(\alpha \approx 2\alpha_i+\alpha_o\).
+   * conversion method is upper-bounded by \(\alpha =
+   * \frac{(1+\alpha_i)(1+\alpha_o)}{1-\alpha_i}-1\). If relative accuracies are small, this is
+   * approximately \(\alpha \approx 2\alpha_i+\alpha_o\).
+   *
+   * <p>That is because this conversion method causes an input data point to be spread over the full
+   * width of a bin of the initial mapping, hence a multiplicative shift of up to \(\gamma_i =
+   * \frac{1+\alpha_i}{1-\alpha_i}\) to the right, and down to \(\frac{1}{\gamma_i}\) to the left.
+   * In addition, because of the relative error induced by the new mapping, transferring counts to
+   * the new mapping will cause an additional multiplicative shift of up to \(1+\alpha_o\) to the
+   * right, and down to \(1-\alpha_o\) to the left. Therefore, the resulting relative error is up to
+   * \(\alpha = \gamma_i(1+\alpha_o)-1\) to the right and up to \(\alpha' =
+   * 1-\frac{1-\alpha_o}{\gamma_i}\) to the left. Because \(\alpha-\alpha' =
+   * \frac{1}{\gamma_i}((\gamma_i^2-1)\alpha_o+(\gamma_i-1)^2) \geq 0\) (given that \(\gamma_i \geq
+   * 1\) and \(\alpha_o \geq 0\)), the resulting relative error is upper-bounded by \(\alpha =
+   * \gamma_i(1+\alpha_o)-1 = \frac{(1+\alpha_i)(1+\alpha_o)}{1-\alpha_i}-1\).
    *
    * @return a converter that uniformly distributes the count of a bin to the overlapping bins of
    *     the new mapping depending on the shares of the initial bin that the new bins cover

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
@@ -1,0 +1,107 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.mapping;
+
+import com.datadoghq.sketch.ddsketch.store.Bin;
+import com.datadoghq.sketch.ddsketch.store.BinAcceptor;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * An interface for converting bins that have been encoded using an {@link IndexMapping} to bins
+ * encoded using another one.
+ */
+public interface IndexMappingConverter {
+
+  /**
+   * Converts bins.
+   *
+   * @param inBins an ascending iterator, that is, an iterator that returns bins whose indexes are
+   *     sorted in ascending order
+   * @param outBins a consumer that is fed the converted bins
+   * @throws IllegalArgumentException if the provided iterator is not ascending
+   */
+  void convertAscendingIterator(Iterator<Bin> inBins, BinAcceptor outBins);
+
+  /**
+   * Returns a converter that uniformly distributes the count of a bin to the overlapping bins of
+   * the new mapping based on the shares of the initial bin that the new bins cover.
+   *
+   * <p>This conversion method is not the one that minimizes the relative accuracy of the quantiles
+   * that are computed from the resulting bins. For instance, transferring the full count of a bin
+   * of the initial mapping to the single bin of the new mapping that overlaps {@link
+   * IndexMapping#value(int)} of the initial mapping allows computing more accurate quantiles.
+   * However, this method produces better-looking histograms and avoids conversion artifacts that
+   * would cause empty bins or bins with counts that are excessively high relative to its
+   * neighbors'.
+   *
+   * <p>If \(\alpha_i\) is the relative accuracy of the initial mapping {@code inMapping},
+   * \(\alpha_o\) the relative accuracy of the new mapping {@code outMapping}, and assuming that the
+   * initial bins are not themselves resulting from a conversion (in which case \(\alpha_i\) needs
+   * to be adjusted to be the effective relative accuracy of the initial bins), the effective
+   * relative accuracy of the quantiles that are computed from the bins that result from this
+   * conversion method is upper-bounded by \(\alpha = \frac{\gamma-1}{\gamma+1}\) where \(\gamma =
+   * \gamma_i^2\gamma_o\), \(\gamma_i = \frac{1+\alpha_i}{1-\alpha_i}\), and \(\gamma_o =
+   * \frac{1+\alpha_o}{1-\alpha_o}\). If relative accuracies are small, this is approximately
+   * \(\alpha \approx 2\alpha_i+\alpha_o\).
+   *
+   * @return a converter that uniformly distributes the count of a bin to the overlapping bins of
+   *     the new mapping depending on the shares of the initial bin that the new bins cover
+   */
+  static IndexMappingConverter distributingUniformly(
+      IndexMapping inMapping, IndexMapping outMapping) {
+    Objects.requireNonNull(inMapping);
+    Objects.requireNonNull(outMapping);
+    return (inBins, outBins) -> {
+      Integer inIndex = null;
+      int outIndex = Integer.MIN_VALUE;
+      double value = 0;
+      double outCount = 0;
+
+      while (inBins.hasNext()) {
+        final Bin inBin = inBins.next();
+
+        if (inIndex != null && inBin.getIndex() <= inIndex) {
+          throw new IllegalArgumentException("The bin iterator is not ascending.");
+        }
+        inIndex = inBin.getIndex();
+
+        final double inLowerBound = inMapping.lowerBound(inBin.getIndex());
+        final double inUpperBound = inMapping.upperBound(inBin.getIndex());
+
+        if (inLowerBound < value) {
+          throw new RuntimeException("The input mapping is invalid.");
+        }
+        value = inLowerBound;
+
+        final int newOutIndex = outMapping.index(value);
+        if (newOutIndex < outIndex) {
+          throw new RuntimeException("The output mapping is invalid.");
+        } else if (newOutIndex > outIndex && outCount != 0) {
+          outBins.accept(outIndex, outCount);
+          outCount = 0;
+        }
+        outIndex = newOutIndex;
+
+        double outUpperBound;
+        while ((outUpperBound = outMapping.upperBound(outIndex)) < inUpperBound) {
+          outCount += inBin.getCount() * (outUpperBound - value) / (inUpperBound - inLowerBound);
+          value = outUpperBound;
+          if (outCount != 0) {
+            outBins.accept(outIndex, outCount);
+            outCount = 0;
+          }
+          outIndex++;
+        }
+        outCount += inBin.getCount() * (inUpperBound - value) / (inUpperBound - inLowerBound);
+      }
+
+      if (outCount != 0) {
+        outBins.accept(outIndex, outCount);
+      }
+    };
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
@@ -59,6 +59,25 @@ public interface IndexMappingConverter {
    * 1\) and \(\alpha_o \geq 0\)), the resulting relative error is upper-bounded by \(\alpha =
    * \gamma_i(1+\alpha_o)-1 = \frac{(1+\alpha_i)(1+\alpha_o)}{1-\alpha_i}-1\).
    *
+   * <p>In other words, this conversion method causes a single point to be spread over the full
+   * width of a bin of the initial mapping, inducing a relative error up to approximately
+   * \(2\alpha_i\). In addition, the allocation of counts to the bins of the new mapping causes a
+   * relative error that is up to approximately \(\alpha_o\). Informally, here is what can happen in
+   * the worst case:
+   *
+   * <pre>
+   * single input value:                                      x
+   * initial mapping:                       -|-------o-------|-------o-------|-------o-------|
+   * max (q_1) after bin encoding (1):                               x
+   * count spreading over full bin (2):                      [---------------]
+   * new mapping:                           |---o---|---o---|---o---|---o---|---o---|---o---|-
+   * non-empty bins after conversion (3):                       o       o       o
+   * max after conversion:                                                      x
+   * </pre>
+   *
+   * The resulting value at quantile \(1\) (i.e., the maximum value) is shifted by \(\alpha_i\)
+   * because of (1), an additional \(\alpha_i\) because of (2) and \(\alpha_o\) because of (3).
+   *
    * @return a converter that uniformly distributes the count of a bin to the overlapping bins of
    *     the new mapping depending on the shares of the initial bin that the new bins cover
    */

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverter.java
@@ -86,6 +86,8 @@ public interface IndexMappingConverter {
         }
         outIndex = newOutIndex;
 
+        // Allocate shares of the count of the current input bin to the overlapping bins of the
+        // output mapping whose upper bounds are still within the input bin.
         double outUpperBound;
         while ((outUpperBound = outMapping.upperBound(outIndex)) < inUpperBound) {
           outCount += inBin.getCount() * (outUpperBound - value) / (inUpperBound - inLowerBound);
@@ -96,9 +98,14 @@ public interface IndexMappingConverter {
           }
           outIndex++;
         }
+        // Allocate the remaining of the count of the current input bin to the rightmost overlapping
+        // bin. Do not transfer it to outBins just yet as other input bins may also overlap the
+        // output bin of index outIndex (we want to forward the whole resulting count at once).
         outCount += inBin.getCount() * (inUpperBound - value) / (inUpperBound - inLowerBound);
       }
 
+      // No other input bin overlaps the output bin of index outIndex. Forward its count to
+      // outBins.
       if (outCount != 0) {
         outBins.accept(outIndex, outCount);
       }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -81,7 +81,17 @@ abstract class LogLikeIndexMapping implements IndexMapping {
 
   @Override
   public final double value(int index) {
-    return logInverse((index - normalizedIndexOffset) / multiplier) * (1 + relativeAccuracy);
+    return lowerBound(index) * (1 + relativeAccuracy);
+  }
+
+  @Override
+  public double lowerBound(int index) {
+    return logInverse((index - normalizedIndexOffset) / multiplier);
+  }
+
+  @Override
+  public double upperBound(int index) {
+    return lowerBound(index + 1);
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Bin.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Bin.java
@@ -52,4 +52,9 @@ public final class Bin {
   public int hashCode() {
     return Objects.hash(index, count);
   }
+
+  @Override
+  public String toString() {
+    return "Bin{index=" + index + ", count=" + count + '}';
+  }
 }

--- a/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
@@ -5,11 +5,14 @@
 
 package com.datadoghq.sketch;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.datadoghq.sketch.util.accuracy.AccuracyTester;
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
@@ -17,10 +20,14 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
+import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
+
+  protected static final double EPSILON = AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR;
+  private static final Offset<Double> DOUBLE_OFFSET = offset(EPSILON);
 
   protected abstract QS newSketch();
 
@@ -98,7 +105,7 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
   }
 
   protected final void assertEncodes(boolean merged, double[] values, QS sketch) {
-    assertEquals(values.length, sketch.getCount());
+    assertThat(sketch.getCount()).isCloseTo(values.length, DOUBLE_OFFSET);
     if (values.length == 0) {
       assertTrue(sketch.isEmpty());
     } else {
@@ -128,8 +135,6 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
 
       assertSumAccurate(values, sketch.getSum());
       assertAverageAccurate(values, sketch.getAverage());
-
-      assertEquals(values.length, sketch.getCount());
     }
   }
 

--- a/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
@@ -6,8 +6,10 @@
 package com.datadoghq.sketch.ddsketch;
 
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.datadoghq.sketch.QuantileSketchTest;
+import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.mapping.IndexMapping;
 import com.datadoghq.sketch.ddsketch.mapping.LogarithmicMapping;
 import com.datadoghq.sketch.ddsketch.store.Store;
@@ -18,7 +20,11 @@ import java.util.Arrays;
 import java.util.function.Supplier;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
 
@@ -212,6 +218,86 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
         DDSketchProtoBinding.fromProto(
             storeSupplier(),
             com.datadoghq.sketch.ddsketch.proto.DDSketch.parseFrom(sketch.serialize())));
+  }
+
+  @ParameterizedTest
+  @MethodSource("values")
+  void testConversion(double[] values) {
+    final double gamma = (1 + relativeAccuracy()) / (1 - relativeAccuracy());
+
+    final double initialGamma = Math.pow(gamma, 0.3);
+    final double initialRelativeAccuracy = (initialGamma - 1) / (initialGamma + 1);
+    final IndexMapping initialIndexMapping =
+        new BitwiseLinearlyInterpolatedMapping(initialRelativeAccuracy);
+    final DDSketch initialSketch = new DDSketch(initialIndexMapping, UnboundedSizeDenseStore::new);
+    Arrays.stream(values).forEach(initialSketch);
+
+    final double newGamma = Math.pow(gamma, 0.4); // initialGamma^2 * newGamma <= gamma
+    final double newRelativeAccuracy = (newGamma - 1) / (newGamma + 1);
+    final IndexMapping newIndexMapping = new LogarithmicMapping(newRelativeAccuracy);
+    final DDSketch convertedSketch =
+        initialSketch.convert(newIndexMapping, UnboundedSizeDenseStore::new);
+
+    assertEncodes(false, values, convertedSketch);
+  }
+
+  static Stream<Arguments> values() {
+    return Stream.of(
+        arguments(new Object[] {new double[] {0}}),
+        arguments(new Object[] {new double[] {-1}}),
+        arguments(new Object[] {new double[] {-1, -1, -1}}),
+        arguments(new Object[] {new double[] {-1, -1, -1, 1, 1, 1}}),
+        arguments(new Object[] {new double[] {-10, -10, -10}}),
+        arguments(new Object[] {new double[] {-10, -10, -10, 10, 10, 10}}),
+        arguments(new Object[] {IntStream.range(0, 10000).mapToDouble(i -> -2).toArray()}),
+        arguments(
+            new Object[] {
+              IntStream.range(0, 20000).mapToDouble(i -> i % 2 == 0 ? 2 : -2).toArray()
+            }),
+        arguments(new Object[] {new double[] {-10, -10, -11, -11, -11}}),
+        arguments(new Object[] {new double[] {-10, -10, -11, -11, -11, 10, 10, 11, 11, 11}}),
+        arguments(new Object[] {IntStream.range(0, 100).mapToDouble(i -> 0).toArray()}),
+        arguments(
+            new Object[] {
+              DoubleStream.concat(
+                      IntStream.range(0, 10).mapToDouble(i -> 0),
+                      IntStream.range(-100, 100).mapToDouble(i -> i))
+                  .toArray()
+            }),
+        arguments(
+            new Object[] {
+              DoubleStream.concat(
+                      IntStream.range(-100, 100).mapToDouble(i -> i),
+                      IntStream.range(0, 10).mapToDouble(i -> 0))
+                  .toArray()
+            }),
+        arguments(
+            new Object[] {
+              DoubleStream.concat(
+                      IntStream.range(-100, -1).mapToDouble(i -> i),
+                      IntStream.range(1, 100).mapToDouble(i -> i))
+                  .toArray()
+            }),
+        arguments(new Object[] {IntStream.range(-10000, 0).mapToDouble(v -> v).toArray()}),
+        arguments(new Object[] {IntStream.range(-10000, 10000).mapToDouble(v -> v).toArray()}),
+        arguments(new Object[] {IntStream.range(0, 10000).mapToDouble(v -> -v).toArray()}),
+        arguments(new Object[] {IntStream.range(0, 20000).mapToDouble(v -> 10000 - v).toArray()}),
+        arguments(new Object[] {IntStream.range(0, 100).mapToDouble(i -> -Math.exp(i)).toArray()}),
+        arguments(
+            new Object[] {
+              DoubleStream.concat(
+                      IntStream.range(0, 100).mapToDouble(i -> -Math.exp(i)),
+                      IntStream.range(0, 100).mapToDouble(Math::exp))
+                  .toArray()
+            }),
+        arguments(new Object[] {IntStream.range(0, 100).mapToDouble(i -> -Math.exp(-i)).toArray()}),
+        arguments(
+            new Object[] {
+              DoubleStream.concat(
+                      IntStream.range(0, 100).mapToDouble(i -> -Math.exp(-i)),
+                      IntStream.range(0, 100).mapToDouble(i -> Math.exp(-i)))
+                  .toArray()
+            }));
   }
 
   static class DDSketchTest1 extends DDSketchTest {

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverterTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverterTest.java
@@ -1,0 +1,171 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.datadoghq.sketch.ddsketch.store.Bin;
+import com.datadoghq.sketch.ddsketch.store.BinAcceptor;
+import com.datadoghq.sketch.util.accuracy.AccuracyTester;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import org.assertj.core.data.Offset;
+import org.assertj.core.util.DoubleComparator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class IndexMappingConverterTest {
+
+  private static final Offset<Double> DOUBLE_OFFSET =
+      offset(AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
+  private static final RecursiveComparisonConfiguration BIN_COMPARISON_CONFIG =
+      RecursiveComparisonConfiguration.builder()
+          .withIgnoredOverriddenEqualsForTypes(Bin.class)
+          .withComparatorForType(
+              new DoubleComparator(AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR), Double.class)
+          .build();
+
+  private static BinAcceptor listAdder(List<Bin> binList) {
+    return (index, value) -> binList.add(new Bin(index, value));
+  }
+
+  @ParameterizedTest
+  @MethodSource("mappingAndBins")
+  void testSameMapping(IndexMapping mapping, List<Bin> bins) {
+    final List<Bin> outBins = new ArrayList<>();
+    IndexMappingConverter.distributingUniformly(mapping, mapping)
+        .convertAscendingIterator(bins.iterator(), listAdder(outBins));
+
+    assertThat(outBins).usingRecursiveComparison(BIN_COMPARISON_CONFIG).isEqualTo(bins);
+  }
+
+  @ParameterizedTest
+  @MethodSource("twoMappingsAndBins")
+  void testDistinctMappings(IndexMapping inMapping, IndexMapping outMapping, List<Bin> bins) {
+    final List<Bin> outBins = new ArrayList<>();
+    IndexMappingConverter.distributingUniformly(inMapping, outMapping)
+        .convertAscendingIterator(bins.iterator(), listAdder(outBins));
+
+    final List<Integer> indexes = outBins.stream().map(Bin::getIndex).collect(Collectors.toList());
+
+    assertThat(indexes).isSorted();
+    assertThat(indexes).doesNotHaveDuplicates();
+
+    assertThat(outBins.stream().mapToDouble(Bin::getCount).sum())
+        .isCloseTo(bins.stream().mapToDouble(Bin::getCount).sum(), DOUBLE_OFFSET);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bins")
+  void testMergingContiguousBins(List<Bin> bins) {
+    // One bucket of outMapping covers exactly two contiguous buckets of inMapping.
+    final BitwiseLinearlyInterpolatedMapping inMapping = new BitwiseLinearlyInterpolatedMapping(4);
+    final BitwiseLinearlyInterpolatedMapping outMapping = new BitwiseLinearlyInterpolatedMapping(3);
+
+    final List<Bin> outBins = new ArrayList<>();
+    IndexMappingConverter.distributingUniformly(inMapping, outMapping)
+        .convertAscendingIterator(bins.iterator(), listAdder(outBins));
+
+    final List<Bin> mergedBins =
+        bins.stream()
+            .map(bin -> new Bin(Math.floorDiv(bin.getIndex(), 2), bin.getCount()))
+            .collect(
+                Collectors.groupingBy(
+                    Bin::getIndex,
+                    Collectors.mapping(Bin::getCount, Collectors.reducing(0D, Double::sum))))
+            .entrySet()
+            .stream()
+            .map(entry -> new Bin(entry.getKey(), entry.getValue()))
+            .sorted(Comparator.comparing(Bin::getIndex))
+            .collect(Collectors.toList());
+
+    assertThat(outBins).usingRecursiveComparison(BIN_COMPARISON_CONFIG).isEqualTo(mergedBins);
+  }
+
+  @ParameterizedTest
+  @MethodSource("bins")
+  void testIndexShifting(List<Bin> bins) {
+    final double gamma = 1.05;
+    final int indexShift = 4;
+    final LogarithmicMapping inMapping = new LogarithmicMapping(gamma, 0);
+    final LogarithmicMapping outMapping = new LogarithmicMapping(gamma, indexShift);
+
+    final List<Bin> outBins = new ArrayList<>();
+    IndexMappingConverter.distributingUniformly(inMapping, outMapping)
+        .convertAscendingIterator(bins.iterator(), listAdder(outBins));
+
+    final List<Bin> shiftedBins =
+        bins.stream()
+            .map(bin -> new Bin(bin.getIndex() + indexShift, bin.getCount()))
+            .collect(Collectors.toList());
+
+    assertThat(outBins).usingRecursiveComparison(BIN_COMPARISON_CONFIG).isEqualTo(shiftedBins);
+  }
+
+  static Stream<Arguments> mappingAndBins() {
+    return product(mappings(), bins());
+  }
+
+  static Stream<Arguments> twoMappingsAndBins() {
+    return product(mappings(), mappings(), bins());
+  }
+
+  static Stream<Arguments> mappings() {
+    return Stream.of(
+            new LogarithmicMapping(1e-2),
+            new LogarithmicMapping(1.03, 4),
+            new LogarithmicMapping(5e-4),
+            new CubicallyInterpolatedMapping(1.5e-2),
+            new BitwiseLinearlyInterpolatedMapping(1e-3))
+        .map(Arguments::arguments);
+  }
+
+  static Stream<Arguments> bins() {
+    return Stream.of(
+            Collections.singletonList(new Bin(1, 1)),
+            Arrays.asList(new Bin(1, 1), new Bin(2, 1), new Bin(3, 1)),
+            Arrays.asList(new Bin(1, 0.3), new Bin(2, 1.6)),
+            Arrays.asList(new Bin(-1, 0.3), new Bin(3, 1.6)),
+            Arrays.asList(
+                new Bin(-2, 0.3),
+                new Bin(-1, 1.6),
+                new Bin(0, 0.1),
+                new Bin(2, 65),
+                new Bin(3, 5.43)))
+        .map(Arguments::arguments);
+  }
+
+  private static Stream<Arguments> product(List<Stream<Arguments>> streams) {
+    if (streams.isEmpty()) {
+      return Stream.of(arguments());
+    }
+    final List<Arguments> firstArguments = streams.get(0).collect(Collectors.toList());
+    return product(streams.subList(1, streams.size()))
+        .flatMap(
+            other ->
+                firstArguments.stream()
+                    .map(
+                        first ->
+                            arguments(
+                                Stream.concat(
+                                        Arrays.stream(first.get()), Arrays.stream(other.get()))
+                                    .toArray())));
+  }
+
+  @SafeVarargs
+  private static Stream<Arguments> product(Stream<Arguments>... streams) {
+    return product(Arrays.asList(streams));
+  }
+}

--- a/src/test/java/com/datadoghq/sketch/util/accuracy/AccuracyTester.java
+++ b/src/test/java/com/datadoghq/sketch/util/accuracy/AccuracyTester.java
@@ -14,7 +14,7 @@ import java.util.function.DoubleUnaryOperator;
 public abstract class AccuracyTester {
 
   private static final double DEFAULT_QUANTILE_INCREMENT = 0.01;
-  public static final double FLOATING_POINT_ACCEPTABLE_ERROR = 1e-12;
+  public static final double FLOATING_POINT_ACCEPTABLE_ERROR = 1e-10;
 
   private final double[] sortedValues;
 


### PR DESCRIPTION
Those methods can be used to reencode bins and sketches with any index mapping.

Note that in the general case, this degrades the accuracy of the quantiles and summary stats computed from the new bins beyond the relative accuracy of the new index mapping.