### PR TITLE
Add an alternative serialization method

### DIFF
--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/Distributions.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/Distributions.java
@@ -5,21 +5,25 @@
 
 package com.datadoghq.sketch.ddsketch;
 
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 
 public enum Distributions {
   NORMAL {
     @Override
     protected Distribution create(double... parameters) {
-      return () -> parameters[1] * ThreadLocalRandom.current().nextGaussian() + parameters[0];
+      final Random random = new Random(seed);
+      return () -> parameters[1] * random.nextGaussian() + parameters[0];
     }
   },
   POISSON {
     @Override
     protected Distribution create(double... parameters) {
-      return () -> -(Math.log(ThreadLocalRandom.current().nextDouble()) / parameters[0]);
+      final Random random = new Random(seed);
+      return () -> -(Math.log(random.nextDouble()) / parameters[0]);
     }
   };
+
+  private static final long seed = 5388928120325255124L;
 
   public Distribution of(double... parameters) {
     return create(parameters);

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/BuiltSketchState.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/BuiltSketchState.java
@@ -8,6 +8,7 @@ package com.datadoghq.sketch.ddsketch.benchmarks;
 import com.datadoghq.sketch.ddsketch.DDSketch;
 import com.datadoghq.sketch.ddsketch.DDSketchOption;
 import com.datadoghq.sketch.ddsketch.DataGenerator;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 
@@ -29,7 +30,7 @@ public abstract class BuiltSketchState {
   DDSketch sketch;
 
   @Setup(Level.Trial)
-  public void init() {
+  public void init() throws IOException {
     this.sketch = sketchOption.create(relativeAccuracy);
     for (int i = 0; i < count; ++i) {
       sketch.accept(unit.toNanos(Math.abs(Math.round(generator.nextValue()))));

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Deserialize.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Deserialize.java
@@ -31,11 +31,11 @@ public class Deserialize extends BuiltSketchState {
   public void init() throws IOException {
     super.init();
     this.fromProtoData = DDSketchProtoBinding.toProto(sketch).toByteArray();
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     sketch.encode(output, false);
     this.decodeData = output.trimmedCopy();
     this.decodedSketch =
-        DDSketch.decode(new ByteArrayInput(decodeData), sketchOption.getStoreSupplier());
+        DDSketch.decode(ByteArrayInput.wrap(decodeData), sketchOption.getStoreSupplier());
   }
 
   @Benchmark
@@ -47,13 +47,13 @@ public class Deserialize extends BuiltSketchState {
 
   @Benchmark
   public DDSketch decode() throws IOException {
-    return DDSketch.decode(new ByteArrayInput(decodeData), sketchOption.getStoreSupplier());
+    return DDSketch.decode(ByteArrayInput.wrap(decodeData), sketchOption.getStoreSupplier());
   }
 
   @Benchmark
   public DDSketch decodeReusing() throws IOException {
     decodedSketch.clear();
-    decodedSketch.decodeAndMergeWith(new ByteArrayInput(decodeData));
+    decodedSketch.decodeAndMergeWith(ByteArrayInput.wrap(decodeData));
     return decodedSketch;
   }
 }

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Deserialize.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Deserialize.java
@@ -1,0 +1,59 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.benchmarks;
+
+import com.datadoghq.sketch.ddsketch.DDSketch;
+import com.datadoghq.sketch.ddsketch.DDSketchProtoBinding;
+import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
+import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
+import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
+
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class Deserialize extends BuiltSketchState {
+
+  byte[] fromProtoData;
+  byte[] decodeData;
+  DDSketch decodedSketch;
+
+  @Setup(Level.Trial)
+  public void init() throws IOException {
+    super.init();
+    this.fromProtoData = DDSketchProtoBinding.toProto(sketch).toByteArray();
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    sketch.encode(output, false);
+    this.decodeData = output.trimmedCopy();
+    this.decodedSketch =
+        DDSketch.decode(new ByteArrayInput(decodeData), sketchOption.getStoreSupplier());
+  }
+
+  @Benchmark
+  public DDSketch fromProto() throws InvalidProtocolBufferException {
+    return DDSketchProtoBinding.fromProto(
+        sketchOption.getStoreSupplier(),
+        com.datadoghq.sketch.ddsketch.proto.DDSketch.parseFrom(fromProtoData));
+  }
+
+  @Benchmark
+  public DDSketch decode() throws IOException {
+    return DDSketch.decode(new ByteArrayInput(decodeData), sketchOption.getStoreSupplier());
+  }
+
+  @Benchmark
+  public DDSketch decodeReusing() throws IOException {
+    decodedSketch.clear();
+    decodedSketch.decodeAndMergeWith(new ByteArrayInput(decodeData));
+    return decodedSketch;
+  }
+}

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Serialize.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Serialize.java
@@ -25,7 +25,7 @@ public class Serialize extends BuiltSketchState {
   @Setup(Level.Trial)
   public void init() throws IOException {
     super.init();
-    this.output = new GrowingByteArrayOutput();
+    this.output = GrowingByteArrayOutput.withDefaultInitialCapacity();
   }
 
   @Benchmark
@@ -40,7 +40,7 @@ public class Serialize extends BuiltSketchState {
 
   @Benchmark
   public byte[] encode() throws IOException {
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     sketch.encode(output, false);
     return output.trimmedCopy();
   }

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Serialize.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Serialize.java
@@ -23,7 +23,7 @@ public class Serialize extends BuiltSketchState {
   GrowingByteArrayOutput output;
 
   @Setup(Level.Trial)
-  public void init() {
+  public void init() throws IOException {
     super.init();
     this.output = new GrowingByteArrayOutput();
   }

--- a/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Serialize.java
+++ b/src/jmh/java/com/datadoghq/sketch/ddsketch/benchmarks/Serialize.java
@@ -6,15 +6,27 @@
 package com.datadoghq.sketch.ddsketch.benchmarks;
 
 import com.datadoghq.sketch.ddsketch.DDSketchProtoBinding;
+import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Setup;
 
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @BenchmarkMode(Mode.AverageTime)
 public class Serialize extends BuiltSketchState {
+
+  GrowingByteArrayOutput output;
+
+  @Setup(Level.Trial)
+  public void init() {
+    super.init();
+    this.output = new GrowingByteArrayOutput();
+  }
 
   @Benchmark
   public byte[] serialize() {
@@ -24,5 +36,19 @@ public class Serialize extends BuiltSketchState {
   @Benchmark
   public byte[] toProto() {
     return DDSketchProtoBinding.toProto(sketch).toByteArray();
+  }
+
+  @Benchmark
+  public byte[] encode() throws IOException {
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    sketch.encode(output, false);
+    return output.trimmedCopy();
+  }
+
+  @Benchmark
+  public byte[] encodeReusing() throws IOException {
+    output.clear();
+    sketch.encode(output, false);
+    return output.trimmedCopy();
   }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/DDSketch.java
@@ -9,6 +9,13 @@ import static com.datadoghq.sketch.ddsketch.Serializer.doubleFieldSize;
 import static com.datadoghq.sketch.ddsketch.Serializer.embeddedFieldSize;
 
 import com.datadoghq.sketch.QuantileSketch;
+import com.datadoghq.sketch.ddsketch.encoding.BinEncodingMode;
+import com.datadoghq.sketch.ddsketch.encoding.Flag;
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
+import com.datadoghq.sketch.ddsketch.encoding.MalformedInputException;
+import com.datadoghq.sketch.ddsketch.encoding.Output;
+import com.datadoghq.sketch.ddsketch.encoding.VarEncodingHelper;
 import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.mapping.IndexMapping;
 import com.datadoghq.sketch.ddsketch.mapping.IndexMappingConverter;
@@ -18,6 +25,7 @@ import com.datadoghq.sketch.ddsketch.store.CollapsingHighestDenseStore;
 import com.datadoghq.sketch.ddsketch.store.CollapsingLowestDenseStore;
 import com.datadoghq.sketch.ddsketch.store.Store;
 import com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -230,15 +238,18 @@ public class DDSketch implements QuantileSketch<DDSketch> {
    */
   @Override
   public void mergeWith(DDSketch other) {
-
-    if (!indexMapping.equals(other.indexMapping)) {
-      throw new IllegalArgumentException(
-          "The sketches are not mergeable because they do not use the same index mappings.");
-    }
-
+    checkMergeability(indexMapping, other.indexMapping);
     negativeValueStore.mergeWith(other.negativeValueStore);
     positiveValueStore.mergeWith(other.positiveValueStore);
     zeroCount += other.zeroCount;
+  }
+
+  private static void checkMergeability(IndexMapping indexMapping1, IndexMapping indexMapping2)
+      throws IllegalArgumentException {
+    if (!indexMapping1.equals(indexMapping2)) {
+      throw new IllegalArgumentException(
+          "The sketches are not mergeable because they do not use the same index mappings.");
+    }
   }
 
   @Override
@@ -374,6 +385,93 @@ public class DDSketch implements QuantileSketch<DDSketch> {
 
     return new DDSketch(
         newIndexMapping, newNegativeValueStore, newPositiveValueStore, zeroCount, minIndexedValue);
+  }
+
+  public void encode(Output output, boolean omitIndexMapping) throws IOException {
+    if (!omitIndexMapping) {
+      indexMapping.encode(output);
+    }
+
+    if (zeroCount != 0) {
+      Flag.ZERO_COUNT.encode(output);
+      VarEncodingHelper.encodeVarDouble(output, zeroCount);
+    }
+
+    positiveValueStore.encode(output, Flag.Type.POSITIVE_STORE);
+    negativeValueStore.encode(output, Flag.Type.NEGATIVE_STORE);
+  }
+
+  public void decodeAndMergeWith(Input input) throws IOException {
+    final DecodingState state =
+        new DecodingState(indexMapping, negativeValueStore, positiveValueStore, zeroCount);
+    decodeAndMergeWith(state, input);
+    zeroCount = state.zeroCount;
+  }
+
+  public static DDSketch decode(Input input, Supplier<Store> storeSupplier) throws IOException {
+    return decode(input, storeSupplier, null);
+  }
+
+  public static DDSketch decode(
+      Input input, Supplier<Store> storeSupplier, IndexMapping indexMapping) throws IOException {
+    final DecodingState state =
+        new DecodingState(indexMapping, storeSupplier.get(), storeSupplier.get(), 0);
+    decodeAndMergeWith(state, input);
+    if (state.indexMapping == null) {
+      throw new IllegalArgumentException("The index mapping is missing.");
+    }
+    return new DDSketch(
+        state.indexMapping, state.negativeValueStore, state.positiveValueStore, state.zeroCount);
+  }
+
+  private static void decodeAndMergeWith(DecodingState state, Input input) throws IOException {
+    while (input.hasRemaining()) {
+      final Flag flag = Flag.decode(input);
+      switch (flag.type()) {
+        case POSITIVE_STORE:
+          state.positiveValueStore.decodeAndMergeWith(input, BinEncodingMode.ofFlag(flag));
+          break;
+        case NEGATIVE_STORE:
+          state.negativeValueStore.decodeAndMergeWith(input, BinEncodingMode.ofFlag(flag));
+          break;
+        case INDEX_MAPPING:
+          final IndexMapping decodedIndexMapping =
+              IndexMapping.decode(input, IndexMappingLayout.ofFlag(flag));
+          if (state.indexMapping == null) {
+            state.indexMapping = decodedIndexMapping;
+          } else {
+            checkMergeability(state.indexMapping, decodedIndexMapping);
+          }
+          break;
+        case SKETCH_FEATURES:
+          if (Flag.ZERO_COUNT.equals(flag)) {
+            state.zeroCount += VarEncodingHelper.decodeVarDouble(input);
+          } else {
+            throw new MalformedInputException("The flag is invalid.");
+          }
+          break;
+        default:
+          throw new MalformedInputException("The flag type is invalid.");
+      }
+    }
+  }
+
+  private static final class DecodingState {
+    private IndexMapping indexMapping;
+    private final Store negativeValueStore;
+    private final Store positiveValueStore;
+    private double zeroCount;
+
+    private DecodingState(
+        IndexMapping indexMapping,
+        Store negativeValueStore,
+        Store positiveValueStore,
+        double zeroCount) {
+      this.indexMapping = indexMapping;
+      this.negativeValueStore = negativeValueStore;
+      this.positiveValueStore = positiveValueStore;
+      this.zeroCount = zeroCount;
+    }
   }
 
   /** @return the size of the sketch when serialized in protobuf */

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/BinEncodingMode.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/BinEncodingMode.java
@@ -1,0 +1,76 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+public enum BinEncodingMode {
+  /**
+   * Encodes N bins, each one with its index and its count. Indexes are delta-encoded.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[uvarint64] number of bins N
+   *   <li>[varint64] index of first bin
+   *   <li>[varfloat64] count of first bin
+   *   <li>[varint64] difference between the index of the second bin and the index of the first bin
+   *   <li>[varfloat64] count of second bin
+   *   <li>...
+   *   <li>[varint64] difference between the index of the N-th bin and the index of the (N-1)-th bin
+   *   <li>[varfloat64] count of N-th bin
+   * </ul>
+   */
+  INDEX_DELTAS_AND_COUNTS((byte) 1),
+  /**
+   * Encodes N bins whose counts are each equal to 1. Indexes are delta-encoded.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[uvarint64] number of bins N
+   *   <li>[varint64] index of first bin
+   *   <li>[varint64] difference between the index of the second bin and the index of the first bin
+   *   <li>...
+   *   <li>[varint64] difference between the index of the N-th bin and the index of the (N-1)-th bin
+   * </ul>
+   */
+  INDEX_DELTAS((byte) 2),
+  /**
+   * Encodes N contiguous bins, specifying the count of each one.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[uvarint64] number of bins N
+   *   <li>[varint64] index of first bin
+   *   <li>[varfloat64] count of first bin
+   *   <li>[varfloat64] count of second bin
+   *   <li>...
+   *   <li>[varfloat64] count of N-th bin
+   * </ul>
+   */
+  CONTIGUOUS_COUNTS((byte) 3);
+
+  private final byte subFlag;
+
+  BinEncodingMode(byte subFlag) {
+    this.subFlag = subFlag;
+  }
+
+  public final Flag toFlag(Flag.Type storeFlagType) {
+    return new Flag(storeFlagType, subFlag);
+  }
+
+  public static BinEncodingMode ofFlag(Flag flag) throws InvalidFlagException {
+    final int index = (flag.marker() >>> 2) - 1;
+    if (index < 0 || index >= values().length) {
+      throw new InvalidFlagException("The flag does not encode any valid bin encoding mode.");
+    }
+    return values()[index];
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/ByteArrayInput.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/ByteArrayInput.java
@@ -16,7 +16,7 @@ public final class ByteArrayInput implements Input {
   private final int endPos;
   private int pos;
 
-  public ByteArrayInput(byte[] array, int offset, int length) {
+  private ByteArrayInput(byte[] array, int offset, int length) {
     Objects.requireNonNull(array);
     if (offset < 0 || offset + length > array.length) {
       throw new IndexOutOfBoundsException();
@@ -26,8 +26,12 @@ public final class ByteArrayInput implements Input {
     this.pos = offset;
   }
 
-  public ByteArrayInput(byte[] array) {
-    this(array, 0, array.length);
+  public static ByteArrayInput wrap(byte[] array, int offset, int length) {
+    return new ByteArrayInput(array, offset, length);
+  }
+
+  public static ByteArrayInput wrap(byte[] array) {
+    return wrap(array, 0, array.length);
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/ByteArrayInput.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/ByteArrayInput.java
@@ -1,0 +1,63 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.util.Objects;
+
+/** An implementation of {@link Input} that is backed by an array. */
+public final class ByteArrayInput implements Input {
+
+  private final byte[] array;
+  private final int endPos;
+  private int pos;
+
+  public ByteArrayInput(byte[] array, int offset, int length) {
+    Objects.requireNonNull(array);
+    if (offset < 0 || offset + length > array.length) {
+      throw new IndexOutOfBoundsException();
+    }
+    this.array = array;
+    this.endPos = offset + length;
+    this.pos = offset;
+  }
+
+  public ByteArrayInput(byte[] array) {
+    this(array, 0, array.length);
+  }
+
+  @Override
+  public final boolean hasRemaining() {
+    return pos < endPos;
+  }
+
+  @Override
+  public final byte readByte() throws EOFException {
+    if (pos >= endPos) {
+      throw new EOFException();
+    }
+    return array[pos++];
+  }
+
+  @Override
+  public final long readLongLE() throws IOException {
+    if (pos > endPos - 8) {
+      throw new EOFException();
+    }
+    long value = 0;
+    value |= Byte.toUnsignedLong(array[pos]);
+    value |= Byte.toUnsignedLong(array[pos + 1]) << 8;
+    value |= Byte.toUnsignedLong(array[pos + 2]) << 16;
+    value |= Byte.toUnsignedLong(array[pos + 3]) << 24;
+    value |= Byte.toUnsignedLong(array[pos + 4]) << 32;
+    value |= Byte.toUnsignedLong(array[pos + 5]) << 40;
+    value |= Byte.toUnsignedLong(array[pos + 6]) << 48;
+    value |= Byte.toUnsignedLong(array[pos + 7]) << 56;
+    pos += 8;
+    return value;
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Flag.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Flag.java
@@ -1,0 +1,106 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * An encoded DDSketch comprises multiple contiguous blocks (sequences of bytes). Each block is
+ * prefixed with a flag that indicates what the block contains and how the data is encoded in the
+ * block.
+ *
+ * <p>A flag is a encoded with a single byte, which itself contains two parts:
+ *
+ * <ul>
+ *   <li>the flag type (the 2 least significant bits),
+ *   <li>the subflag (the 6 most significant bits).
+ * </ul>
+ *
+ * <p>There are four flag types, for:
+ *
+ * <ul>
+ *   <li>the sketch features,
+ *   <li>the index mapping,
+ *   <li>the positive value store,
+ *   <li>the negative value store.
+ * </ul>
+ *
+ * <p>The meaning of the subflag depends on the flag type:
+ *
+ * <ul>
+ *   <li>for the sketch feature flag type, it indicates what feature is encoded,
+ *   <li>for the index mapping flag type, it indicates what mapping is encoded and how,
+ *   <li>for the store flag types, it indicates how bins are encoded.
+ * </ul>
+ */
+public final class Flag {
+
+  /**
+   * Encodes the count of the zero bin.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[varfloat64] count of the zero bin
+   * </ul>
+   */
+  public static final Flag ZERO_COUNT = new Flag(Type.SKETCH_FEATURES, (byte) 1);
+
+  private final byte marker;
+
+  private Flag(byte marker) {
+    this.marker = marker;
+  }
+
+  Flag(Type type, byte subFlag) {
+    this((byte) (type.ordinal() | (subFlag << 2)));
+  }
+
+  final byte marker() {
+    return marker;
+  }
+
+  public Type type() {
+    return Type.values()[marker & 3];
+  }
+
+  public void encode(Output output) throws IOException {
+    output.writeByte(marker);
+  }
+
+  /**
+   * Return a flag built from the data read from the provided {@code Input}.
+   *
+   * <p>Note that for performance reasons, there is no validation happening in this method while
+   * decoding the flag. As a consequence, the returned flag may not actually be a valid flag.
+   *
+   * @param input where to read from
+   * @return the flag built from the data immediately read from the {@code input}
+   * @throws IOException if an IO exception is thrown while reading from the {@code input}
+   */
+  public static Flag decode(Input input) throws IOException {
+    return new Flag(input.readByte());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o != null && getClass() == o.getClass() && marker == ((Flag) o).marker;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(marker);
+  }
+
+  public enum Type {
+    SKETCH_FEATURES, // 0b00
+    POSITIVE_STORE, // 0b01
+    INDEX_MAPPING, // 0b10
+    NEGATIVE_STORE // 0b11
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/GrowingByteArrayOutput.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/GrowingByteArrayOutput.java
@@ -5,6 +5,8 @@
 
 package com.datadoghq.sketch.ddsketch.encoding;
 
+import java.util.Arrays;
+
 /**
  * An implementation of {@link Output} that is backed by an array of bytes, whose capacity is grown
  * as necessary.
@@ -81,8 +83,6 @@ public final class GrowingByteArrayOutput implements Output {
    *     size is {@link #numWrittenBytes()})
    */
   public final byte[] trimmedCopy() {
-    final byte[] copy = new byte[pos];
-    System.arraycopy(array, 0, copy, 0, copy.length);
-    return copy;
+    return Arrays.copyOf(array, pos);
   }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/GrowingByteArrayOutput.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/GrowingByteArrayOutput.java
@@ -1,0 +1,88 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+/**
+ * An implementation of {@link Output} that is backed by an array of bytes, whose capacity is grown
+ * as necessary.
+ */
+public final class GrowingByteArrayOutput implements Output {
+
+  private static final int INITIAL_CAPACITY = 8;
+
+  private byte[] array;
+  private int pos = 0; // invariant: pos <= array.length
+
+  public GrowingByteArrayOutput(int initialCapacity) {
+    if (initialCapacity < 0) {
+      throw new IllegalArgumentException("Capacity cannot be negative");
+    }
+    this.array = new byte[initialCapacity];
+  }
+
+  public GrowingByteArrayOutput() {
+    this(INITIAL_CAPACITY);
+  }
+
+  private void grow(int requiredCapacity) {
+    final int newCapacity = Math.max(requiredCapacity, array.length << 1);
+    final byte[] newArray = new byte[newCapacity];
+    System.arraycopy(array, 0, newArray, 0, array.length);
+    array = newArray;
+  }
+
+  @Override
+  public final void writeByte(byte value) {
+    if (pos == array.length) {
+      grow(pos + 1);
+    }
+    array[pos++] = value;
+  }
+
+  @Override
+  public final void writeLongLE(long value) {
+    if (pos > array.length - 8) {
+      grow(pos + 8);
+    }
+    array[pos] = (byte) value;
+    array[pos + 1] = (byte) (value >> 8);
+    array[pos + 2] = (byte) (value >> 16);
+    array[pos + 3] = (byte) (value >> 24);
+    array[pos + 4] = (byte) (value >> 32);
+    array[pos + 5] = (byte) (value >> 40);
+    array[pos + 6] = (byte) (value >> 48);
+    array[pos + 7] = (byte) (value >> 56);
+    pos += 8;
+  }
+
+  /** Discard the data that has been written to the backing array but avoid deallocating memory. */
+  public final void clear() {
+    pos = 0;
+  }
+
+  /**
+   * @return the array that contains the written data, and possibly some additional trailing bytes;
+   *     its {@link #numWrittenBytes()} bytes match what {@link #trimmedCopy()} would return
+   */
+  public final byte[] backingArray() {
+    return array;
+  }
+
+  /** @return the number of bytes that have been written to the backing array */
+  public final int numWrittenBytes() {
+    return pos;
+  }
+
+  /**
+   * @return an array that is distinct from the backing array that contains the written data (its
+   *     size is {@link #numWrittenBytes()})
+   */
+  public final byte[] trimmedCopy() {
+    final byte[] copy = new byte[pos];
+    System.arraycopy(array, 0, copy, 0, copy.length);
+    return copy;
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/GrowingByteArrayOutput.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/GrowingByteArrayOutput.java
@@ -18,15 +18,19 @@ public final class GrowingByteArrayOutput implements Output {
   private byte[] array;
   private int pos = 0; // invariant: pos <= array.length
 
-  public GrowingByteArrayOutput(int initialCapacity) {
+  private GrowingByteArrayOutput(int initialCapacity) {
     if (initialCapacity < 0) {
       throw new IllegalArgumentException("Capacity cannot be negative");
     }
     this.array = new byte[initialCapacity];
   }
 
-  public GrowingByteArrayOutput() {
-    this(INITIAL_CAPACITY);
+  public static GrowingByteArrayOutput withInitialCapacity(int initialCapacity) {
+    return new GrowingByteArrayOutput(initialCapacity);
+  }
+
+  public static GrowingByteArrayOutput withDefaultInitialCapacity() {
+    return withInitialCapacity(INITIAL_CAPACITY);
   }
 
   private void grow(int requiredCapacity) {

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/IndexMappingLayout.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/IndexMappingLayout.java
@@ -1,0 +1,91 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+public enum IndexMappingLayout {
+  /**
+   * Encodes the logarithmic index mapping, specifying the base \(\gamma\) and the index offset.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] gamma
+   *   <li>[float64LE] index offset
+   * </ul>
+   */
+  LOG,
+  /**
+   * Encodes the logarithmic index mapping with linear interpolation between powers of 2, specifying
+   * the base \(\gamma\) and the index offset.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] gamma
+   *   <li>[float64LE] index offset
+   * </ul>
+   */
+  LOG_LINEAR,
+  /**
+   * Encodes the logarithmic index mapping with quadratic interpolation between powers of 2,
+   * specifying the base \(\gamma\) and the index offset.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] gamma
+   *   <li>[float64LE] index offset
+   * </ul>
+   */
+  LOG_QUADRATIC,
+  /**
+   * Encodes the logarithmic index mapping with cubic interpolation between powers of 2, specifying
+   * the base \(\gamma\) and the index offset.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] gamma
+   *   <li>[float64LE] index offset
+   * </ul>
+   */
+  LOG_CUBIC,
+  /**
+   * Encodes the logarithmic index mapping with wuartic interpolation between powers of 2,
+   * specifying the base \(\gamma\) and the index offset.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] gamma
+   *   <li>[float64LE] index offset
+   * </ul>
+   */
+  LOG_QUARTIC;
+
+  private final Flag flag;
+
+  IndexMappingLayout() {
+    this.flag = new Flag(Flag.Type.INDEX_MAPPING, (byte) ordinal());
+  }
+
+  public final Flag toFlag() {
+    return flag;
+  }
+
+  public static IndexMappingLayout ofFlag(Flag flag) throws InvalidFlagException {
+    final int index = flag.marker() >>> 2;
+    if (index >= values().length) {
+      throw new InvalidFlagException("The flag does not encode any valid index mapping layout.");
+    }
+    return values()[index];
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Input.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Input.java
@@ -1,0 +1,43 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+import java.io.IOException;
+
+/** A generic interface for reading data from a stream or an object. */
+public interface Input {
+
+  boolean hasRemaining() throws IOException;
+
+  /**
+   * @return the next read byte
+   * @throws java.io.EOFException iff a prior call to {@link #hasRemaining()} would have returned
+   *     false
+   */
+  byte readByte() throws IOException;
+
+  /**
+   * @return the 64-bit integer value built from the next 8 bytes, the least significant byte being
+   *     first
+   * @throws java.io.EOFException iff there are fewer than 8 remaining bytes to read
+   */
+  default long readLongLE() throws IOException {
+    long value = 0;
+    value |= Byte.toUnsignedLong(readByte());
+    value |= Byte.toUnsignedLong(readByte()) << 8;
+    value |= Byte.toUnsignedLong(readByte()) << 16;
+    value |= Byte.toUnsignedLong(readByte()) << 24;
+    value |= Byte.toUnsignedLong(readByte()) << 32;
+    value |= Byte.toUnsignedLong(readByte()) << 40;
+    value |= Byte.toUnsignedLong(readByte()) << 48;
+    value |= Byte.toUnsignedLong(readByte()) << 56;
+    return value;
+  }
+
+  default double readDoubleLE() throws IOException {
+    return Double.longBitsToDouble(readLongLE());
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/InvalidFlagException.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/InvalidFlagException.java
@@ -1,0 +1,15 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+/** Signals that an encoded flag does not match any valid flag. */
+public class InvalidFlagException extends MalformedInputException {
+  public InvalidFlagException() {}
+
+  public InvalidFlagException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/MalformedInputException.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/MalformedInputException.java
@@ -1,0 +1,19 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+import java.io.IOException;
+
+/**
+ * Signals that the input data is in an unrecognized or inappropriate format and cannot be decoded.
+ */
+public class MalformedInputException extends IOException {
+  public MalformedInputException() {}
+
+  public MalformedInputException(String msg) {
+    super(msg);
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Output.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Output.java
@@ -1,0 +1,29 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+import java.io.IOException;
+
+/** A generic interface for writing to a stream or an object. */
+public interface Output {
+
+  void writeByte(byte value) throws IOException;
+
+  default void writeLongLE(long value) throws IOException {
+    writeByte((byte) value);
+    writeByte((byte) (value >> 8));
+    writeByte((byte) (value >> 16));
+    writeByte((byte) (value >> 24));
+    writeByte((byte) (value >> 32));
+    writeByte((byte) (value >> 40));
+    writeByte((byte) (value >> 48));
+    writeByte((byte) (value >> 56));
+  }
+
+  default void writeDoubleLE(double value) throws IOException {
+    writeLongLE(Double.doubleToRawLongBits(value));
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
@@ -14,6 +14,17 @@ public final class VarEncodingHelper {
 
   private VarEncodingHelper() {}
 
+  /**
+   * {@code encodeUnsignedVarLong} serializes {@code long} values 7 bits at a time, starting with
+   * the least significant bits. The most significant bit in each output byte is the continuation
+   * bit and indicates whether there are additional non-zero bits encoded in following bytes. There
+   * are at most 9 output bytes and the last one does not have a continuation bit, allowing for it
+   * to encode 8 bits (\(8*7+8 = 64\)).
+   *
+   * @param output what to write to
+   * @param value the value to encode
+   * @throws IOException if an {@link IOException} is thrown while writing to {@code output}
+   */
   public static void encodeUnsignedVarLong(final Output output, long value) throws IOException {
     for (int i = 0; i < MAX_VAR_LEN_64 - 1; i++) {
       if (value >= 0 && value < 0x80L) {
@@ -25,6 +36,14 @@ public final class VarEncodingHelper {
     output.writeByte((byte) value);
   }
 
+  /**
+   * {@code decodeUnsignedVarLong} deserializes {@code long} values that have been encoded using
+   * {@link #encodeUnsignedVarLong(Output, long)}.
+   *
+   * @param input what to read from
+   * @return the decoded value
+   * @throws IOException if an {@link IOException} is thrown while reading from {@code input}
+   */
   public static long decodeUnsignedVarLong(final Input input) throws IOException {
     long value = 0;
     for (int shift = 0; ; shift += 7) {
@@ -36,15 +55,54 @@ public final class VarEncodingHelper {
     }
   }
 
+  /**
+   * {@code encodeSignedVarLong} serializes {@code long} values using zig-zag encoding, which
+   * ensures small-scale integers are turned into integers that have leading zeros, whether they are
+   * positive or negative, hence allows for space-efficient encoding of those values.
+   *
+   * @param output what to write to
+   * @param value the value to encode
+   * @throws IOException if an {@link IOException} is thrown while writing to {@code output}
+   */
   public static void encodeSignedVarLong(final Output output, final long value) throws IOException {
     encodeUnsignedVarLong(output, (value >> (64 - 1) ^ (value << 1)));
   }
 
+  /**
+   * {@code decodeSignedVarLong} deserializes {@code long} values that have been encoded using
+   * {@link #encodeSignedVarLong(Output, long)}.
+   *
+   * @param input what to read from
+   * @return the decoded value
+   * @throws IOException if an {@link IOException} is thrown while reading from {@code input}
+   */
   public static long decodeSignedVarLong(final Input input) throws IOException {
     final long value = decodeUnsignedVarLong(input);
     return (value >>> 1) ^ -(value & 1);
   }
 
+  /**
+   * {@code encodeVarDouble} serializes {@code double} values using a method that is similar to the
+   * varint encoding and that is space-efficient for non-negative integer values. The output takes
+   * at most 9 bytes.
+   *
+   * <p>Input values are first shifted as floating-point values ({@code +1}), then transmuted to
+   * integer values, then shifted again as integer values ({@code -Double.doubleToRawLongBits(1)}).
+   * That is in order to minimize the number of non-zero bits when dealing with non-negative integer
+   * values.
+   *
+   * <p>After that transformation, any input integer value no greater than \(2^{53}\) (the largest
+   * integer value that can be encoded exactly as a 64-bit floating-point value) will have at least
+   * 6 leading zero bits. By rotating bits to the left, those bits end up at the right of the binary
+   * representation.
+   *
+   * <p>The resulting bits are then encoded similarly to the varint method, but starting with the
+   * most significant bits.
+   *
+   * @param output what to write to
+   * @param value the value to encode
+   * @throws IOException if an {@link IOException} is thrown while writing to {@code output}
+   */
   public static void encodeVarDouble(final Output output, final double value) throws IOException {
     long bits =
         Long.rotateLeft(
@@ -62,6 +120,14 @@ public final class VarEncodingHelper {
     output.writeByte((byte) (bits >>> (8 * 7)));
   }
 
+  /**
+   * {@code decodeSignedVarLong} deserializes {@code double} values that have been encoded using
+   * {@link #encodeVarDouble(Output, double)}.
+   *
+   * @param input what to read from
+   * @return the decoded value
+   * @throws IOException if an {@link IOException} is thrown while reading from {@code input}
+   */
   public static double decodeVarDouble(final Input input) throws IOException {
     long bits = 0;
     for (int shift = 8 * 8 - 7; ; shift -= 7) {

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
@@ -26,10 +26,8 @@ public final class VarEncodingHelper {
    * @throws IOException if an {@link IOException} is thrown while writing to {@code output}
    */
   public static void encodeUnsignedVarLong(final Output output, long value) throws IOException {
-    for (int i = 0; i < MAX_VAR_LEN_64 - 1; i++) {
-      if (value >= 0 && value < 0x80L) {
-        break;
-      }
+    final int length = (63 - Long.numberOfLeadingZeros(value)) / 7;
+    for (int i = 0; i < length && i < 8; i++) {
       output.writeByte((byte) (value | 0x80L));
       value >>>= 7;
     }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
@@ -1,0 +1,83 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+import java.io.IOException;
+
+public final class VarEncodingHelper {
+
+  private static final int MAX_VAR_LEN_64 = 9;
+  private static final int VAR_DOUBLE_ROTATE_DISTANCE = 6;
+
+  private VarEncodingHelper() {}
+
+  public static void encodeUnsignedVarLong(final Output output, long value) throws IOException {
+    for (int i = 0; i < MAX_VAR_LEN_64 - 1; i++) {
+      if (value >= 0 && value < 0x80L) {
+        break;
+      }
+      output.writeByte((byte) (value | 0x80L));
+      value >>>= 7;
+    }
+    output.writeByte((byte) value);
+  }
+
+  public static long decodeUnsignedVarLong(final Input input) throws IOException {
+    long value = 0;
+    for (int shift = 0; ; shift += 7) {
+      final byte next = input.readByte();
+      if (next >= 0 || shift == 7 * 8) {
+        return value | ((long) next << shift);
+      }
+      value |= ((long) next & 0x7FL) << shift;
+    }
+  }
+
+  public static void encodeSignedVarLong(final Output output, final long value) throws IOException {
+    encodeUnsignedVarLong(output, (value >> (64 - 1) ^ (value << 1)));
+  }
+
+  public static long decodeSignedVarLong(final Input input) throws IOException {
+    final long value = decodeUnsignedVarLong(input);
+    return (value >>> 1) ^ -(value & 1);
+  }
+
+  public static void encodeVarDouble(final Output output, final double value) throws IOException {
+    long bits =
+        Long.rotateLeft(
+            Double.doubleToRawLongBits(value + 1) - Double.doubleToRawLongBits(1),
+            VAR_DOUBLE_ROTATE_DISTANCE);
+    for (int i = 0; i < MAX_VAR_LEN_64 - 1; i++) {
+      final byte next = (byte) (bits >>> (8 * 8 - 7));
+      bits <<= 7;
+      if (bits == 0) {
+        output.writeByte(next);
+        return;
+      }
+      output.writeByte((byte) (next | 0x80L));
+    }
+    output.writeByte((byte) (bits >>> (8 * 7)));
+  }
+
+  public static double decodeVarDouble(final Input input) throws IOException {
+    long bits = 0;
+    for (int shift = 8 * 8 - 7; ; shift -= 7) {
+      final byte next = input.readByte();
+      if (shift == 1) {
+        bits |= Byte.toUnsignedLong(next);
+        break;
+      }
+      if (next >= 0) {
+        bits |= (long) next << shift;
+        break;
+      }
+      bits |= ((long) next & 0x7FL) << shift;
+    }
+    return Double.longBitsToDouble(
+            Long.rotateRight(bits, VAR_DOUBLE_ROTATE_DISTANCE) + Double.doubleToRawLongBits(1))
+        - 1;
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
@@ -9,6 +9,9 @@ import static com.datadoghq.sketch.ddsketch.Serializer.*;
 import static com.datadoghq.sketch.ddsketch.mapping.Interpolation.LINEAR;
 
 import com.datadoghq.sketch.ddsketch.Serializer;
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+import com.datadoghq.sketch.ddsketch.encoding.Output;
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -102,6 +105,13 @@ public class BitwiseLinearlyInterpolatedMapping implements IndexMapping {
     return Math.min(
         Math.pow(2, Integer.MAX_VALUE / multiplier), // so that index <= Integer.MAX_VALUE
         Double.MAX_VALUE / (1 + relativeAccuracy));
+  }
+
+  @Override
+  public void encode(Output output) throws IOException {
+    IndexMappingLayout.LOG_LINEAR.toFlag().encode(output);
+    output.writeDoubleLE(gamma());
+    output.writeDoubleLE(0);
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -7,6 +7,8 @@ package com.datadoghq.sketch.ddsketch.mapping;
 
 import static com.datadoghq.sketch.ddsketch.mapping.Interpolation.CUBIC;
 
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+
 /**
  * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link
  * LogarithmicMapping}) by extracting the floor value of the logarithm to the base 2 from the binary
@@ -115,6 +117,11 @@ public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
   @Override
   double correctingFactor() {
     return 7 / (10 * Math.log(2));
+  }
+
+  @Override
+  IndexMappingLayout layout() {
+    return IndexMappingLayout.LOG_CUBIC;
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/IndexMapping.java
@@ -6,6 +6,10 @@
 package com.datadoghq.sketch.ddsketch.mapping;
 
 import com.datadoghq.sketch.ddsketch.Serializer;
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
+import com.datadoghq.sketch.ddsketch.encoding.Output;
+import java.io.IOException;
 
 /**
  * A mapping between {@code double} positive values and {@code int} values that imposes relative
@@ -104,6 +108,27 @@ public interface IndexMapping {
   double minIndexableValue();
 
   double maxIndexableValue();
+
+  void encode(Output output) throws IOException;
+
+  static IndexMapping decode(Input input, IndexMappingLayout layout) throws IOException {
+    final double gamma = input.readDoubleLE();
+    final double indexOffset = input.readDoubleLE();
+    switch (layout) {
+      case LOG:
+        return new LogarithmicMapping(gamma, indexOffset);
+      case LOG_LINEAR:
+        return new LinearlyInterpolatedMapping(gamma, indexOffset);
+      case LOG_QUADRATIC:
+        return new QuadraticallyInterpolatedMapping(gamma, indexOffset);
+      case LOG_CUBIC:
+        return new CubicallyInterpolatedMapping(gamma, indexOffset);
+      case LOG_QUARTIC:
+        return new QuarticallyInterpolatedMapping(gamma, indexOffset);
+      default:
+        throw new IllegalStateException("The index mapping layout is not handled.");
+    }
+  }
 
   int serializedSize();
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
@@ -7,6 +7,8 @@ package com.datadoghq.sketch.ddsketch.mapping;
 
 import static com.datadoghq.sketch.ddsketch.mapping.Interpolation.LINEAR;
 
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+
 /**
  * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link
  * LogarithmicMapping}) by extracting the floor value of the logarithm to the base 2 from the binary
@@ -45,6 +47,11 @@ public class LinearlyInterpolatedMapping extends LogLikeIndexMapping {
   @Override
   double correctingFactor() {
     return 1 / Math.log(2);
+  }
+
+  @Override
+  IndexMappingLayout layout() {
+    return IndexMappingLayout.LOG_LINEAR;
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -8,6 +8,9 @@ package com.datadoghq.sketch.ddsketch.mapping;
 import static com.datadoghq.sketch.ddsketch.Serializer.*;
 
 import com.datadoghq.sketch.ddsketch.Serializer;
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+import com.datadoghq.sketch.ddsketch.encoding.Output;
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -137,6 +140,15 @@ abstract class LogLikeIndexMapping implements IndexMapping {
   @Override
   public int hashCode() {
     return Objects.hash(multiplier, normalizedIndexOffset);
+  }
+
+  abstract IndexMappingLayout layout();
+
+  @Override
+  public void encode(Output output) throws IOException {
+    layout().toFlag().encode(output);
+    output.writeDoubleLE(gamma());
+    output.writeDoubleLE(indexOffset());
   }
 
   abstract Interpolation interpolation();

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
@@ -7,6 +7,8 @@ package com.datadoghq.sketch.ddsketch.mapping;
 
 import static com.datadoghq.sketch.ddsketch.mapping.Interpolation.NONE;
 
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+
 /**
  * An {@link IndexMapping} that is <i>memory-optimal</i>, that is to say that given a targeted
  * relative accuracy, it requires the least number of indices to cover a given range of values. This
@@ -41,6 +43,11 @@ public class LogarithmicMapping extends LogLikeIndexMapping {
   @Override
   double correctingFactor() {
     return 1;
+  }
+
+  @Override
+  IndexMappingLayout layout() {
+    return IndexMappingLayout.LOG;
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
@@ -7,6 +7,8 @@ package com.datadoghq.sketch.ddsketch.mapping;
 
 import static com.datadoghq.sketch.ddsketch.mapping.Interpolation.QUADRATIC;
 
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+
 /**
  * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link
  * LogarithmicMapping}) by extracting the floor value of the logarithm to the base 2 from the binary
@@ -49,6 +51,11 @@ public class QuadraticallyInterpolatedMapping extends LogLikeIndexMapping {
   @Override
   double correctingFactor() {
     return 3 / (4 * Math.log(2));
+  }
+
+  @Override
+  IndexMappingLayout layout() {
+    return IndexMappingLayout.LOG_QUADRATIC;
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
@@ -5,6 +5,8 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+
 /**
  * A fast {@link IndexMapping} that approximates the memory-optimal one (namely {@link
  * LogarithmicMapping}) by extracting the floor value of the logarithm to the base 2 from the binary
@@ -67,6 +69,11 @@ public class QuarticallyInterpolatedMapping extends LogLikeIndexMapping {
   @Override
   double correctingFactor() {
     return 25 / (36 * Math.log(2));
+  }
+
+  @Override
+  IndexMappingLayout layout() {
+    return IndexMappingLayout.LOG_QUARTIC;
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
@@ -6,6 +6,11 @@
 package com.datadoghq.sketch.ddsketch.store;
 
 import com.datadoghq.sketch.ddsketch.Serializer;
+import com.datadoghq.sketch.ddsketch.encoding.BinEncodingMode;
+import com.datadoghq.sketch.ddsketch.encoding.Flag;
+import com.datadoghq.sketch.ddsketch.encoding.Output;
+import com.datadoghq.sketch.ddsketch.encoding.VarEncodingHelper;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -321,6 +326,19 @@ public abstract class DenseStore implements Store {
         return new Bin(nextIndex, counts[nextIndex - offset]);
       }
     };
+  }
+
+  @Override
+  public void encode(Output output, Flag.Type storeFlagType) throws IOException {
+    if (isEmpty()) {
+      return;
+    }
+    BinEncodingMode.CONTIGUOUS_COUNTS.toFlag(storeFlagType).encode(output);
+    VarEncodingHelper.encodeUnsignedVarLong(output, (long) maxIndex - (long) minIndex + 1);
+    VarEncodingHelper.encodeSignedVarLong(output, minIndex);
+    for (int i = minIndex - offset; i <= maxIndex - offset; i++) {
+      VarEncodingHelper.encodeVarDouble(output, counts[i]);
+    }
   }
 
   @Override

--- a/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
@@ -231,13 +231,13 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
 
   void testEncodeDecode(
       boolean merged, double[] values, DDSketch sketch, Supplier<Store> finalStoreSupplier) {
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       sketch.encode(output, false);
     } catch (IOException e) {
       fail(e);
     }
-    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
     final DDSketch decoded;
     try {
       decoded = DDSketch.decode(input, finalStoreSupplier);
@@ -262,7 +262,7 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
     final IndexMapping mapping1 = new QuadraticallyInterpolatedMapping(relativeAccuracy());
     final DDSketch sketch1 = new DDSketch(mapping1, storeSupplier());
     sketch1.accept(0.9);
-    final GrowingByteArrayOutput output1 = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output1 = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       sketch1.encode(output1, false);
     } catch (IOException e) {
@@ -271,7 +271,7 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
 
     final IndexMapping mapping2 = new CubicallyInterpolatedMapping(relativeAccuracy());
     final DDSketch sketch2 = new DDSketch(mapping2, storeSupplier());
-    final GrowingByteArrayOutput output2 = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output2 = GrowingByteArrayOutput.withDefaultInitialCapacity();
     sketch2.accept(0.8);
     try {
       sketch2.encode(output2, false);
@@ -279,7 +279,7 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
       fail(e);
     }
 
-    final Input input1 = new ByteArrayInput(output1.backingArray(), 0, output1.numWrittenBytes());
+    final Input input1 = ByteArrayInput.wrap(output1.backingArray(), 0, output1.numWrittenBytes());
     final DDSketch decoded;
     try {
       decoded = DDSketch.decode(input1, storeSupplier());
@@ -290,7 +290,7 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
     }
     assertThat(decoded.getIndexMapping().getClass()).isEqualTo(mapping1.getClass());
 
-    final Input input2 = new ByteArrayInput(output2.backingArray(), 0, output2.numWrittenBytes());
+    final Input input2 = ByteArrayInput.wrap(output2.backingArray(), 0, output2.numWrittenBytes());
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> decoded.decodeAndMergeWith(input2));
   }
@@ -300,13 +300,13 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
     final IndexMapping mapping = mapping();
     final DDSketch sketch = new DDSketch(mapping, storeSupplier());
 
-    final GrowingByteArrayOutput output1 = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output1 = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       mapping.encode(output1);
     } catch (IOException e) {
       fail(e);
     }
-    final Input input1 = new ByteArrayInput(output1.backingArray(), 0, output1.numWrittenBytes());
+    final Input input1 = ByteArrayInput.wrap(output1.backingArray(), 0, output1.numWrittenBytes());
     try {
       DDSketch.decode(input1, storeSupplier());
       assertThat(input1.hasRemaining()).isFalse();
@@ -315,17 +315,17 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
       return;
     }
 
-    final Input input2 = new ByteArrayInput(new byte[] {});
+    final Input input2 = ByteArrayInput.wrap(new byte[] {});
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> DDSketch.decode(input2, storeSupplier()));
 
-    final GrowingByteArrayOutput output3 = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output3 = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       sketch.encode(output3, false);
     } catch (IOException e) {
       fail(e);
     }
-    final Input input3 = new ByteArrayInput(output3.backingArray(), 0, output3.numWrittenBytes());
+    final Input input3 = ByteArrayInput.wrap(output3.backingArray(), 0, output3.numWrittenBytes());
     try {
       DDSketch.decode(input3, storeSupplier());
       assertThat(input3.hasRemaining()).isFalse();
@@ -333,13 +333,13 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
       fail(e);
     }
 
-    final GrowingByteArrayOutput output4 = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output4 = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       sketch.encode(output4, true);
     } catch (IOException e) {
       fail(e);
     }
-    final Input input4 = new ByteArrayInput(output4.backingArray(), 0, output4.numWrittenBytes());
+    final Input input4 = ByteArrayInput.wrap(output4.backingArray(), 0, output4.numWrittenBytes());
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> DDSketch.decode(input4, storeSupplier()));
   }
@@ -351,16 +351,16 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
     final DDSketch sketch1 = newSketch();
     sketch0.accept(values[0]);
     sketch1.accept(values[1]);
-    final GrowingByteArrayOutput output0 = new GrowingByteArrayOutput();
-    final GrowingByteArrayOutput output1 = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output0 = GrowingByteArrayOutput.withDefaultInitialCapacity();
+    final GrowingByteArrayOutput output1 = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       sketch0.encode(output0, false);
       sketch1.encode(output1, false);
     } catch (IOException e) {
       fail(e);
     }
-    final Input input0 = new ByteArrayInput(output0.backingArray(), 0, output0.numWrittenBytes());
-    final Input input1 = new ByteArrayInput(output1.backingArray(), 0, output1.numWrittenBytes());
+    final Input input0 = ByteArrayInput.wrap(output0.backingArray(), 0, output0.numWrittenBytes());
+    final Input input1 = ByteArrayInput.wrap(output1.backingArray(), 0, output1.numWrittenBytes());
     final DDSketch decoded;
     try {
       decoded = DDSketch.decode(input0, storeSupplier());
@@ -381,14 +381,14 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
     final DDSketch sketch1 = newSketch();
     sketch0.accept(values[0]);
     sketch1.accept(values[1]);
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       sketch0.encode(output, false);
       sketch1.encode(output, false);
     } catch (IOException e) {
       fail(e);
     }
-    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
     final DDSketch decoded;
     try {
       decoded = DDSketch.decode(input, storeSupplier());

--- a/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
@@ -5,17 +5,25 @@
 
 package com.datadoghq.sketch.ddsketch;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.datadoghq.sketch.QuantileSketchTest;
+import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
+import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
 import com.datadoghq.sketch.ddsketch.mapping.BitwiseLinearlyInterpolatedMapping;
+import com.datadoghq.sketch.ddsketch.mapping.CubicallyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.mapping.IndexMapping;
 import com.datadoghq.sketch.ddsketch.mapping.LogarithmicMapping;
+import com.datadoghq.sketch.ddsketch.mapping.QuadraticallyInterpolatedMapping;
 import com.datadoghq.sketch.ddsketch.store.Store;
+import com.datadoghq.sketch.ddsketch.store.StoreTestCase;
 import com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore;
 import com.datadoghq.sketch.util.accuracy.AccuracyTester;
 import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.function.Supplier;
 import java.util.stream.DoubleStream;
@@ -204,6 +212,7 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
     } catch (InvalidProtocolBufferException e) {
       fail(e);
     }
+    testEncodeDecode(merged, values, sketch);
   }
 
   void testProtoRoundTrip(boolean merged, double[] values, DDSketch sketch)
@@ -218,6 +227,177 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
         DDSketchProtoBinding.fromProto(
             storeSupplier(),
             com.datadoghq.sketch.ddsketch.proto.DDSketch.parseFrom(sketch.serialize())));
+  }
+
+  void testEncodeDecode(
+      boolean merged, double[] values, DDSketch sketch, Supplier<Store> finalStoreSupplier) {
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    try {
+      sketch.encode(output, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final DDSketch decoded;
+    try {
+      decoded = DDSketch.decode(input, finalStoreSupplier);
+      assertThat(input.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertEncodes(merged, values, decoded);
+  }
+
+  void testEncodeDecode(boolean merged, double[] values, DDSketch sketch) {
+    Arrays.stream(StoreTestCase.values())
+        .filter(StoreTestCase::isLossless)
+        .forEach(
+            storeTestCase ->
+                testEncodeDecode(merged, values, sketch, storeTestCase.storeSupplier()));
+  }
+
+  @Test
+  void testIndexMappingEncodingMismatch() {
+    final IndexMapping mapping1 = new QuadraticallyInterpolatedMapping(relativeAccuracy());
+    final DDSketch sketch1 = new DDSketch(mapping1, storeSupplier());
+    sketch1.accept(0.9);
+    final GrowingByteArrayOutput output1 = new GrowingByteArrayOutput();
+    try {
+      sketch1.encode(output1, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+
+    final IndexMapping mapping2 = new CubicallyInterpolatedMapping(relativeAccuracy());
+    final DDSketch sketch2 = new DDSketch(mapping2, storeSupplier());
+    final GrowingByteArrayOutput output2 = new GrowingByteArrayOutput();
+    sketch2.accept(0.8);
+    try {
+      sketch2.encode(output2, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+
+    final Input input1 = new ByteArrayInput(output1.backingArray(), 0, output1.numWrittenBytes());
+    final DDSketch decoded;
+    try {
+      decoded = DDSketch.decode(input1, storeSupplier());
+      assertThat(input1.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertThat(decoded.getIndexMapping().getClass()).isEqualTo(mapping1.getClass());
+
+    final Input input2 = new ByteArrayInput(output2.backingArray(), 0, output2.numWrittenBytes());
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> decoded.decodeAndMergeWith(input2));
+  }
+
+  @Test
+  void testMissingIndexMappingEncoding() {
+    final IndexMapping mapping = mapping();
+    final DDSketch sketch = new DDSketch(mapping, storeSupplier());
+
+    final GrowingByteArrayOutput output1 = new GrowingByteArrayOutput();
+    try {
+      mapping.encode(output1);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input1 = new ByteArrayInput(output1.backingArray(), 0, output1.numWrittenBytes());
+    try {
+      DDSketch.decode(input1, storeSupplier());
+      assertThat(input1.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+
+    final Input input2 = new ByteArrayInput(new byte[] {});
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> DDSketch.decode(input2, storeSupplier()));
+
+    final GrowingByteArrayOutput output3 = new GrowingByteArrayOutput();
+    try {
+      sketch.encode(output3, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input3 = new ByteArrayInput(output3.backingArray(), 0, output3.numWrittenBytes());
+    try {
+      DDSketch.decode(input3, storeSupplier());
+      assertThat(input3.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+    }
+
+    final GrowingByteArrayOutput output4 = new GrowingByteArrayOutput();
+    try {
+      sketch.encode(output4, true);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input4 = new ByteArrayInput(output4.backingArray(), 0, output4.numWrittenBytes());
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> DDSketch.decode(input4, storeSupplier()));
+  }
+
+  @Test
+  void testDecodeAndMergeWith() {
+    final double[] values = new double[] {0.33, -7};
+    final DDSketch sketch0 = newSketch();
+    final DDSketch sketch1 = newSketch();
+    sketch0.accept(values[0]);
+    sketch1.accept(values[1]);
+    final GrowingByteArrayOutput output0 = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output1 = new GrowingByteArrayOutput();
+    try {
+      sketch0.encode(output0, false);
+      sketch1.encode(output1, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input0 = new ByteArrayInput(output0.backingArray(), 0, output0.numWrittenBytes());
+    final Input input1 = new ByteArrayInput(output1.backingArray(), 0, output1.numWrittenBytes());
+    final DDSketch decoded;
+    try {
+      decoded = DDSketch.decode(input0, storeSupplier());
+      decoded.decodeAndMergeWith(input1);
+      assertThat(input0.hasRemaining()).isFalse();
+      assertThat(input1.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertEncodes(true, values, decoded);
+  }
+
+  @Test
+  void testMergingByConcatenatingEncoded() {
+    final double[] values = new double[] {0.33, -7};
+    final DDSketch sketch0 = newSketch();
+    final DDSketch sketch1 = newSketch();
+    sketch0.accept(values[0]);
+    sketch1.accept(values[1]);
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    try {
+      sketch0.encode(output, false);
+      sketch1.encode(output, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final DDSketch decoded;
+    try {
+      decoded = DDSketch.decode(input, storeSupplier());
+      assertThat(input.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertEncodes(true, values, decoded);
   }
 
   @ParameterizedTest

--- a/src/test/java/com/datadoghq/sketch/ddsketch/TestHelper.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/TestHelper.java
@@ -1,0 +1,50 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch;
+
+import com.datadoghq.sketch.ddsketch.store.Bin;
+import com.datadoghq.sketch.util.accuracy.AccuracyTester;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import org.assertj.core.util.DoubleComparator;
+import org.junit.jupiter.params.provider.Arguments;
+
+public final class TestHelper {
+
+  public static final RecursiveComparisonConfiguration BIN_COMPARISON_CONFIG =
+      RecursiveComparisonConfiguration.builder()
+          .withIgnoredOverriddenEqualsForTypes(Bin.class)
+          .withComparatorForType(
+              new DoubleComparator(AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR), Double.class)
+          .build();
+
+  public static Stream<Arguments> product(List<Stream<Arguments>> streams) {
+    if (streams.isEmpty()) {
+      return Stream.of(Arguments.of());
+    }
+    final List<Arguments> firstArguments = streams.get(0).collect(Collectors.toList());
+    return product(streams.subList(1, streams.size()))
+        .flatMap(
+            other ->
+                firstArguments.stream()
+                    .map(
+                        first ->
+                            Arguments.of(
+                                Stream.concat(
+                                        Arrays.stream(first.get()), Arrays.stream(other.get()))
+                                    .toArray())));
+  }
+
+  @SafeVarargs
+  public static Stream<Arguments> product(Stream<Arguments>... streams) {
+    return product(Arrays.asList(streams));
+  }
+
+  private TestHelper() {}
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelperTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelperTest.java
@@ -20,7 +20,7 @@ class VarEncodingHelperTest {
   @ParameterizedTest
   @MethodSource("unsignedVarLongs")
   void testEncodeUnsignedVarLong(long value, byte[] bytes) {
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       VarEncodingHelper.encodeUnsignedVarLong(output, value);
     } catch (IOException e) {
@@ -33,7 +33,7 @@ class VarEncodingHelperTest {
   @ParameterizedTest
   @MethodSource("unsignedVarLongs")
   void testDecodeUnsignedVarLong(long value, byte[] bytes) {
-    final Input input = new ByteArrayInput(bytes);
+    final Input input = ByteArrayInput.wrap(bytes);
     final long decoded;
     try {
       decoded = VarEncodingHelper.decodeUnsignedVarLong(input);
@@ -87,7 +87,7 @@ class VarEncodingHelperTest {
   @ParameterizedTest
   @MethodSource("signedVarLongs")
   void testEncodeSignedVarLong(long value, byte[] bytes) {
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       VarEncodingHelper.encodeSignedVarLong(output, value);
     } catch (IOException e) {
@@ -100,7 +100,7 @@ class VarEncodingHelperTest {
   @ParameterizedTest
   @MethodSource("signedVarLongs")
   void testDecodeSignedVarLong(long value, byte[] bytes) {
-    final Input input = new ByteArrayInput(bytes);
+    final Input input = ByteArrayInput.wrap(bytes);
     final long decoded;
     try {
       decoded = VarEncodingHelper.decodeSignedVarLong(input);
@@ -267,7 +267,7 @@ class VarEncodingHelperTest {
   @ParameterizedTest
   @MethodSource("varDoubles")
   void testEncodeVarDouble(double value, byte[] bytes) {
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       VarEncodingHelper.encodeVarDouble(output, value);
     } catch (IOException e) {
@@ -280,7 +280,7 @@ class VarEncodingHelperTest {
   @ParameterizedTest
   @MethodSource("varDoubles")
   void testDecodeVarDouble(double value, byte[] bytes) {
-    final Input input = new ByteArrayInput(bytes);
+    final Input input = ByteArrayInput.wrap(bytes);
     final double decoded;
     try {
       decoded = VarEncodingHelper.decodeVarDouble(input);

--- a/src/test/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelperTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelperTest.java
@@ -1,0 +1,374 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class VarEncodingHelperTest {
+
+  @ParameterizedTest
+  @MethodSource("unsignedVarLongs")
+  void testEncodeUnsignedVarLong(long value, byte[] bytes) {
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    try {
+      VarEncodingHelper.encodeUnsignedVarLong(output, value);
+    } catch (IOException e) {
+      fail(e.toString());
+      return;
+    }
+    assertThat(output.trimmedCopy()).isEqualTo(bytes);
+  }
+
+  @ParameterizedTest
+  @MethodSource("unsignedVarLongs")
+  void testDecodeUnsignedVarLong(long value, byte[] bytes) {
+    final Input input = new ByteArrayInput(bytes);
+    final long decoded;
+    try {
+      decoded = VarEncodingHelper.decodeUnsignedVarLong(input);
+    } catch (IOException e) {
+      fail(e.toString());
+      return;
+    }
+    assertThat(decoded).isEqualTo(value);
+  }
+
+  static Stream<Arguments> unsignedVarLongs() {
+    return Stream.of(
+        arguments(0L, new byte[] {0x00}),
+        arguments(1, new byte[] {0x01}),
+        arguments(127, new byte[] {0x7F}),
+        arguments(128, new byte[] {(byte) 0x80, 0x01}),
+        arguments(129, new byte[] {(byte) 0x81, 0x01}),
+        arguments(255, new byte[] {(byte) 0xFF, 0x01}),
+        arguments(256, new byte[] {(byte) 0x80, 0x02}),
+        arguments(16383, new byte[] {(byte) 0xFF, 0x7F}),
+        arguments(16384, new byte[] {(byte) 0x80, (byte) 0x80, 0x01}),
+        arguments(16385, new byte[] {(byte) 0x81, (byte) 0x80, 0x01}),
+        arguments(
+            -2,
+            new byte[] {
+              (byte) 0xFE,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            }),
+        arguments(
+            -1,
+            new byte[] {
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            }));
+  }
+
+  @ParameterizedTest
+  @MethodSource("signedVarLongs")
+  void testEncodeSignedVarLong(long value, byte[] bytes) {
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    try {
+      VarEncodingHelper.encodeSignedVarLong(output, value);
+    } catch (IOException e) {
+      fail(e.toString());
+      return;
+    }
+    assertThat(output.trimmedCopy()).isEqualTo(bytes);
+  }
+
+  @ParameterizedTest
+  @MethodSource("signedVarLongs")
+  void testDecodeSignedVarLong(long value, byte[] bytes) {
+    final Input input = new ByteArrayInput(bytes);
+    final long decoded;
+    try {
+      decoded = VarEncodingHelper.decodeSignedVarLong(input);
+    } catch (IOException e) {
+      fail(e.toString());
+      return;
+    }
+    assertThat(decoded).isEqualTo(value);
+  }
+
+  static Stream<Arguments> signedVarLongs() {
+    return Stream.of(
+        arguments(0L, new byte[] {0x00}),
+        arguments(1L, new byte[] {0x02}),
+        arguments(63L, new byte[] {0x7E}),
+        arguments(64L, new byte[] {(byte) 0x80, 0x01}),
+        arguments(65L, new byte[] {(byte) 0x82, 0x01}),
+        arguments(127L, new byte[] {(byte) 0xFE, 0x01}),
+        arguments(128L, new byte[] {(byte) 0x80, 0x02}),
+        arguments(8191L, new byte[] {(byte) 0xFE, 0x7F}),
+        arguments(8192L, new byte[] {(byte) 0x80, (byte) 0x80, 0x01}),
+        arguments(8193L, new byte[] {(byte) 0x82, (byte) 0x80, 0x01}),
+        arguments(
+            (Long.MAX_VALUE >> 1) - 1L,
+            new byte[] {
+              (byte) 0xFC,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              0x7F
+            }),
+        arguments(
+            Long.MAX_VALUE >> 1,
+            new byte[] {
+              (byte) 0xFE,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              0x7F
+            }),
+        arguments(
+            (Long.MAX_VALUE >> 1) + 1L,
+            new byte[] {
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80
+            }),
+        arguments(
+            Long.MAX_VALUE - 1L,
+            new byte[] {
+              (byte) 0xFC,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            }),
+        arguments(
+            Long.MAX_VALUE,
+            new byte[] {
+              (byte) 0xFE,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            }),
+        arguments(-1L, new byte[] {0x01}),
+        arguments(-63L, new byte[] {0x7D}),
+        arguments(-64L, new byte[] {0x7F}),
+        arguments(-65L, new byte[] {(byte) 0x81, 0x01}),
+        arguments(-127L, new byte[] {(byte) 0xFD, 0x01}),
+        arguments(-128L, new byte[] {(byte) 0xFF, 0x01}),
+        arguments(-8191L, new byte[] {(byte) 0xFD, 0x7F}),
+        arguments(-8192L, new byte[] {(byte) 0xFF, 0x7F}),
+        arguments(-8193L, new byte[] {(byte) 0x81, (byte) 0x80, 0x01}),
+        arguments(
+            (Long.MIN_VALUE >> 1) + 1L,
+            new byte[] {
+              (byte) 0xFD,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              0x7F
+            }),
+        arguments(
+            Long.MIN_VALUE >> 1L,
+            new byte[] {
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              0x7F
+            }),
+        arguments(
+            (Long.MIN_VALUE >> 1) - 1L,
+            new byte[] {
+              (byte) 0x81,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80
+            }),
+        arguments(
+            Long.MIN_VALUE + 1L,
+            new byte[] {
+              (byte) 0xFD,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            }),
+        arguments(
+            Long.MIN_VALUE,
+            new byte[] {
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF
+            }));
+  }
+
+  @ParameterizedTest
+  @MethodSource("varDoubles")
+  void testEncodeVarDouble(double value, byte[] bytes) {
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    try {
+      VarEncodingHelper.encodeVarDouble(output, value);
+    } catch (IOException e) {
+      fail(e.toString());
+      return;
+    }
+    assertThat(output.trimmedCopy()).isEqualTo(bytes);
+  }
+
+  @ParameterizedTest
+  @MethodSource("varDoubles")
+  void testDecodeVarDouble(double value, byte[] bytes) {
+    final Input input = new ByteArrayInput(bytes);
+    final double decoded;
+    try {
+      decoded = VarEncodingHelper.decodeVarDouble(input);
+    } catch (IOException e) {
+      fail(e.toString());
+      return;
+    }
+    assertThat(decoded).isEqualTo(value);
+  }
+
+  static Stream<Arguments> varDoubles() {
+    return Stream.of(
+        arguments(0, new byte[] {0x00}),
+        arguments(1.0, new byte[] {0x02}),
+        arguments(2.0, new byte[] {0x03}),
+        arguments(3.0, new byte[] {0x04}),
+        arguments(4.0, new byte[] {(byte) 0x84, 0x40}),
+        arguments(5.0, new byte[] {0x05}),
+        arguments(6.0, new byte[] {(byte) 0x85, 0x40}),
+        arguments(7.0, new byte[] {0x06}),
+        arguments(8.0, new byte[] {(byte) 0x86, 0x20}),
+        arguments(9.0, new byte[] {(byte) 0x86, 0x40}),
+        arguments(
+            (double) (1L << 52) - 2,
+            new byte[] {
+              (byte) 0xE7,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0x80
+            }),
+        arguments((double) (1L << 52) - 1, new byte[] {0x68}),
+        arguments(
+            (double) (1L << 52),
+            new byte[] {
+              (byte) 0xE8,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              0x40
+            }),
+        arguments(
+            (double) (1L << 53) - 2,
+            new byte[] {
+              (byte) 0xE9,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xFF,
+              (byte) 0xC0
+            }),
+        arguments((double) (1L << 53) - 1, new byte[] {0x6A}),
+        arguments(
+            -1.0,
+            new byte[] {
+              (byte) 0x82,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              0x30
+            }),
+        arguments(
+            -0.5,
+            new byte[] {
+              (byte) 0xFE,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              (byte) 0x80,
+              0x3F
+            }));
+  }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMappingTest.java
@@ -45,14 +45,14 @@ class BitwiseLinearlyInterpolatedMappingTest extends IndexMappingTest {
   @Override
   void testEncodeDecode() {
     final BitwiseLinearlyInterpolatedMapping mapping = getMapping(1e-2);
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       mapping.encode(output);
     } catch (IOException e) {
       fail(e);
     }
 
-    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
     final IndexMapping decoded;
     try {
       final Flag flag = Flag.decode(input);

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMappingTest.java
@@ -6,8 +6,15 @@
 package com.datadoghq.sketch.ddsketch.mapping;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
+import com.datadoghq.sketch.ddsketch.encoding.Flag;
+import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
 import com.datadoghq.sketch.util.accuracy.AccuracyTester;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 class BitwiseLinearlyInterpolatedMappingTest extends IndexMappingTest {
@@ -32,5 +39,35 @@ class BitwiseLinearlyInterpolatedMappingTest extends IndexMappingTest {
         mapping.value(0),
         roundTripMapping.value(0),
         AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
+  }
+
+  @Test
+  @Override
+  void testEncodeDecode() {
+    final BitwiseLinearlyInterpolatedMapping mapping = getMapping(1e-2);
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    try {
+      mapping.encode(output);
+    } catch (IOException e) {
+      fail(e);
+    }
+
+    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final IndexMapping decoded;
+    try {
+      final Flag flag = Flag.decode(input);
+      decoded = IndexMapping.decode(input, IndexMappingLayout.ofFlag(flag));
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    // TODO: decoded could be a BitwiseLinearlyInterpolatedMapping
+    assertEquals(LinearlyInterpolatedMapping.class, decoded.getClass());
+    assertEquals(
+        mapping.relativeAccuracy(),
+        decoded.relativeAccuracy(),
+        AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
+    assertEquals(
+        mapping.value(0), decoded.value(0), AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
   }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverterTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingConverterTest.java
@@ -5,9 +5,10 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
+import static com.datadoghq.sketch.ddsketch.TestHelper.BIN_COMPARISON_CONFIG;
+import static com.datadoghq.sketch.ddsketch.TestHelper.product;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.datadoghq.sketch.ddsketch.store.Bin;
 import com.datadoghq.sketch.ddsketch.store.BinAcceptor;
@@ -19,9 +20,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.assertj.core.data.Offset;
-import org.assertj.core.util.DoubleComparator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -30,12 +29,6 @@ public class IndexMappingConverterTest {
 
   private static final Offset<Double> DOUBLE_OFFSET =
       offset(AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR);
-  private static final RecursiveComparisonConfiguration BIN_COMPARISON_CONFIG =
-      RecursiveComparisonConfiguration.builder()
-          .withIgnoredOverriddenEqualsForTypes(Bin.class)
-          .withComparatorForType(
-              new DoubleComparator(AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR), Double.class)
-          .build();
 
   private static BinAcceptor listAdder(List<Bin> binList) {
     return (index, value) -> binList.add(new Bin(index, value));
@@ -145,27 +138,5 @@ public class IndexMappingConverterTest {
                 new Bin(2, 65),
                 new Bin(3, 5.43)))
         .map(Arguments::arguments);
-  }
-
-  private static Stream<Arguments> product(List<Stream<Arguments>> streams) {
-    if (streams.isEmpty()) {
-      return Stream.of(arguments());
-    }
-    final List<Arguments> firstArguments = streams.get(0).collect(Collectors.toList());
-    return product(streams.subList(1, streams.size()))
-        .flatMap(
-            other ->
-                firstArguments.stream()
-                    .map(
-                        first ->
-                            arguments(
-                                Stream.concat(
-                                        Arrays.stream(first.get()), Arrays.stream(other.get()))
-                                    .toArray())));
-  }
-
-  @SafeVarargs
-  private static Stream<Arguments> product(Stream<Arguments>... streams) {
-    return product(Arrays.asList(streams));
   }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/IndexMappingTest.java
@@ -60,6 +60,9 @@ abstract class IndexMappingTest {
   @Test
   abstract void testProtoRoundTrip();
 
+  @Test
+  abstract void testEncodeDecode();
+
   void testAccuracy(IndexMapping mapping, double relativeAccuracy) {
 
     // Assert that the stated relative accuracy of the mapping is less than or equal to the

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
@@ -72,14 +72,14 @@ abstract class LogLikeIndexMappingTest extends IndexMappingTest {
   @Override
   void testEncodeDecode() {
     final LogLikeIndexMapping mapping = getMapping(1.02, 3);
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       mapping.encode(output);
     } catch (IOException e) {
       fail(e);
     }
 
-    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
     final IndexMapping decoded;
     try {
       final Flag flag = Flag.decode(input);

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
@@ -5,11 +5,18 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.datadoghq.sketch.ddsketch.Serializer;
+import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
+import com.datadoghq.sketch.ddsketch.encoding.Flag;
+import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
+import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
 import com.datadoghq.sketch.util.accuracy.AccuracyTester;
 import com.google.protobuf.InvalidProtocolBufferException;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 abstract class LogLikeIndexMappingTest extends IndexMappingTest {
@@ -59,6 +66,29 @@ abstract class LogLikeIndexMappingTest extends IndexMappingTest {
     } catch (InvalidProtocolBufferException e) {
       fail(e);
     }
+  }
+
+  @Test
+  @Override
+  void testEncodeDecode() {
+    final LogLikeIndexMapping mapping = getMapping(1.02, 3);
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    try {
+      mapping.encode(output);
+    } catch (IOException e) {
+      fail(e);
+    }
+
+    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final IndexMapping decoded;
+    try {
+      final Flag flag = Flag.decode(input);
+      decoded = IndexMapping.decode(input, IndexMappingLayout.ofFlag(flag));
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertThat(decoded).isEqualTo(mapping);
   }
 
   private void assertSameAfterProtoRoundTrip(

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/BinsTestCase.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/BinsTestCase.java
@@ -1,0 +1,87 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.store;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+enum BinsTestCase {
+  EMPTY(),
+  SINGLE_BIN_COUNT_ONE_0(bin(0, 1)),
+  SINGLE_BIN_COUNT_ONE_1(bin(3, 1)),
+  SINGLE_BIN_COUNT_ONE_2(bin(Integer.MAX_VALUE >>> 1, 1)),
+  SINGLE_BIN_COUNT_ONE_3(bin(-3, 1)),
+  SINGLE_BIN_COUNT_ONE_4(bin(Integer.MIN_VALUE >>> 1, 1)),
+  SINGLE_BIN_0(bin(0, 0.1)),
+  SINGLE_BIN_1(bin(3, 178773.2)),
+  SINGLE_BIN_2(bin(Integer.MAX_VALUE >>> 1, 1.2)),
+  SINGLE_BIN_3(bin(-3, 3.123)),
+  SINGLE_BIN_4(bin(Integer.MIN_VALUE >>> 1, 1e-5)),
+  NON_INTEGER_COUNTS_0(
+      IntStream.range(0, 10).mapToObj(i -> bin(i, Math.log(i + 1))).toArray(Bin[]::new)),
+  NON_INTEGER_COUNTS_1(
+      IntStream.range(0, 10).mapToObj(i -> bin(-i, Math.log(i + 1))).toArray(Bin[]::new)),
+  INCREASING_LINEARLY(IntStream.range(0, 10000).mapToObj(BinsTestCase::bin).toArray(Bin[]::new)),
+  DECREASING_LINEARLY(
+      IntStream.range(0, 10000).map(i -> -i).mapToObj(BinsTestCase::bin).toArray(Bin[]::new)),
+  INCREASING_EXPONENTIALLY(
+      IntStream.range(0, 16)
+          .map(i -> (int) Math.pow(2, i))
+          .mapToObj(BinsTestCase::bin)
+          .toArray(Bin[]::new)),
+  DECREASING_EXPONENTIALLY(
+      IntStream.range(0, 16)
+          .map(i -> -(int) Math.pow(2, i))
+          .mapToObj(BinsTestCase::bin)
+          .toArray(Bin[]::new)),
+  MIN_VALUE(bin(Integer.MIN_VALUE)),
+  MAX_VALUE(bin(Integer.MAX_VALUE)),
+  LARGE_RANGE_0(bin(0), bin(Integer.MIN_VALUE)),
+  LARGE_RANGE_1(bin(0), bin(Integer.MAX_VALUE)),
+  LARGE_RANGE_2(bin(Integer.MIN_VALUE), bin(Integer.MAX_VALUE)),
+  LARGE_RANGE_3(bin(Integer.MAX_VALUE), bin(Integer.MIN_VALUE));
+
+  private final Bin[] bins;
+  private final boolean hasLargeRange;
+
+  BinsTestCase(Bin... bins) {
+    this.bins = bins;
+    this.hasLargeRange = hasLargeRange(Arrays.asList(bins));
+  }
+
+  public List<Bin> getBins() {
+    return Arrays.asList(bins);
+  }
+
+  public boolean hasLargeRange() {
+    return hasLargeRange;
+  }
+
+  private static boolean hasLargeRange(Collection<Bin> bins) {
+    if (bins.isEmpty()) {
+      return false;
+    }
+    final int minIndex = bins.stream().mapToInt(Bin::getIndex).min().getAsInt();
+    final int maxIndex = bins.stream().mapToInt(Bin::getIndex).max().getAsInt();
+    return (long) maxIndex - (long) minIndex > Integer.MAX_VALUE >> 1;
+  }
+
+  private static Bin bin(int index, double count) {
+    return new Bin(index, count);
+  }
+
+  private static Bin bin(int index) {
+    return bin(index, 1);
+  }
+
+  public static Stream<Arguments> argStream() {
+    return Arrays.stream(values()).map(Arguments::of);
+  }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/EncodingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/EncodingTest.java
@@ -1,0 +1,104 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.store;
+
+import static com.datadoghq.sketch.ddsketch.TestHelper.BIN_COMPARISON_CONFIG;
+import static com.datadoghq.sketch.ddsketch.TestHelper.product;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.datadoghq.sketch.ddsketch.encoding.BinEncodingMode;
+import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
+import com.datadoghq.sketch.ddsketch.encoding.Flag;
+import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
+import com.datadoghq.sketch.ddsketch.encoding.Output;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class EncodingTest {
+
+  private static final Flag.Type STORE_FLAG_TYPE = Flag.Type.POSITIVE_STORE;
+
+  @ParameterizedTest
+  @MethodSource("binsAndStoreTestCases")
+  void testEncodeDecode(
+      BinsTestCase binsTestCase,
+      StoreTestCase initialStoreTestCase,
+      StoreTestCase finalStoreTestCase) {
+    final Store initialStore = initialStoreTestCase.storeSupplier().get();
+    binsTestCase.getBins().forEach(initialStore::add);
+    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    encode(output, initialStore);
+    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final Store finalStore = finalStoreTestCase.storeSupplier().get();
+    decode(input, finalStore);
+    final Collection<Bin> transformedBins =
+        (initialStoreTestCase
+            .binTransformer()
+            .andThen(finalStoreTestCase.binTransformer())
+            .apply(binsTestCase.getBins()));
+    assertThat(finalStore.getStream())
+        .usingRecursiveComparison(BIN_COMPARISON_CONFIG)
+        .isEqualTo(normalize(transformedBins));
+  }
+
+  static Stream<Arguments> binsAndStoreTestCases() {
+    return product(BinsTestCase.argStream(), StoreTestCase.argStream(), StoreTestCase.argStream())
+        .filter(
+            arguments -> {
+              final BinsTestCase binsTestCase = (BinsTestCase) arguments.get()[0];
+              final StoreTestCase initialStoreTestCase = (StoreTestCase) arguments.get()[1];
+              final StoreTestCase finalStoreTestCase = (StoreTestCase) arguments.get()[2];
+              return !binsTestCase.hasLargeRange()
+                  || (initialStoreTestCase.acceptsLargeRange()
+                      && finalStoreTestCase.acceptsLargeRange());
+            });
+  }
+
+  private static List<Bin> normalize(Collection<Bin> bins) {
+    final Map<Integer, Double> groupedByIndex =
+        bins.stream()
+            .collect(
+                Collectors.groupingBy(
+                    Bin::getIndex,
+                    Collectors.mapping(Bin::getCount, Collectors.reducing(0.0, Double::sum))));
+    return groupedByIndex.entrySet().stream()
+        .filter(entry -> entry.getValue() != 0)
+        .sorted(Map.Entry.comparingByKey())
+        .map(entry -> new Bin(entry.getKey(), entry.getValue()))
+        .collect(Collectors.toList());
+  }
+
+  private static void encode(Output output, Store store) {
+    try {
+      store.encode(output, STORE_FLAG_TYPE);
+    } catch (IOException e) {
+      fail(e);
+    }
+  }
+
+  private static void decode(Input input, Store store) {
+    try {
+      while (input.hasRemaining()) {
+        final Flag flag = Flag.decode(input);
+        if (!STORE_FLAG_TYPE.equals(flag.type())) {
+          fail("Invalid flag type");
+        }
+        store.decodeAndMergeWith(input, BinEncodingMode.ofFlag(flag));
+      }
+    } catch (IOException e) {
+      fail(e);
+    }
+  }
+}

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/EncodingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/EncodingTest.java
@@ -38,9 +38,9 @@ class EncodingTest {
       StoreTestCase finalStoreTestCase) {
     final Store initialStore = initialStoreTestCase.storeSupplier().get();
     binsTestCase.getBins().forEach(initialStore::add);
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     encode(output, initialStore);
-    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
     final Store finalStore = finalStoreTestCase.storeSupplier().get();
     decode(input, finalStore);
     final Collection<Bin> transformedBins =

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTest.java
@@ -82,13 +82,13 @@ abstract class StoreTest {
       fail(e);
     }
     // Test encode-decode round-trip
-    final GrowingByteArrayOutput output = new GrowingByteArrayOutput();
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       store.encode(output, Flag.Type.POSITIVE_STORE);
     } catch (IOException e) {
       fail(e);
     }
-    final Input input = new ByteArrayInput(output.backingArray(), 0, output.numWrittenBytes());
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
     final Store decoded = newStore();
     try {
       while (input.hasRemaining()) {

--- a/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTestCase.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/store/StoreTestCase.java
@@ -1,0 +1,96 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch.store;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.OptionalInt;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+public enum StoreTestCase {
+  PAGINATED(PaginatedStore::new, UnaryOperator.identity(), false),
+  SPARSE(SparseStore::new, UnaryOperator.identity(), true),
+  DENSE_UNBOUNDED(UnboundedSizeDenseStore::new, UnaryOperator.identity(), false),
+  DENSE_COLLAPSING_LOWEST_100(() -> new CollapsingLowestDenseStore(100), collapseLowest(100), true),
+  DENSE_COLLAPSING_HIGHEST_100(
+      () -> new CollapsingHighestDenseStore(100), collapseHighest(100), true);
+
+  private final Supplier<Store> storeSupplier;
+  private final UnaryOperator<Collection<Bin>> binTransformer; // does not necessarily return a copy
+  private final boolean acceptsLargeRange;
+
+  StoreTestCase(
+      Supplier<Store> storeSupplier,
+      UnaryOperator<Collection<Bin>> binTransformer,
+      boolean acceptsLargeRange) {
+    this.storeSupplier = storeSupplier;
+    this.binTransformer = binTransformer;
+    this.acceptsLargeRange = acceptsLargeRange;
+  }
+
+  public Supplier<Store> storeSupplier() {
+    return storeSupplier;
+  }
+
+  public UnaryOperator<Collection<Bin>> binTransformer() {
+    return binTransformer;
+  }
+
+  public boolean isLossless() {
+    // Lossless cases always use UnaryOperator.identity()
+    return UnaryOperator.identity().equals(binTransformer);
+  }
+
+  public boolean acceptsLargeRange() {
+    return acceptsLargeRange;
+  }
+
+  private static UnaryOperator<Collection<Bin>> collapseLowest(final int maxNumBins) {
+    if (maxNumBins <= 0) {
+      throw new IllegalArgumentException();
+    }
+    return bins -> {
+      final OptionalInt maxIndex = bins.stream().mapToInt(Bin::getIndex).max();
+      if (!maxIndex.isPresent()) {
+        return bins;
+      }
+      final int lowerBound =
+          Integer.MIN_VALUE + maxNumBins > maxIndex.getAsInt()
+              ? Integer.MIN_VALUE
+              : maxIndex.getAsInt() - maxNumBins + 1;
+      return bins.stream()
+          .map(bin -> new Bin(Math.max(bin.getIndex(), lowerBound), bin.getCount()))
+          .collect(Collectors.toList());
+    };
+  }
+
+  private static UnaryOperator<Collection<Bin>> collapseHighest(final int maxNumBins) {
+    if (maxNumBins <= 0) {
+      throw new IllegalArgumentException();
+    }
+    return bins -> {
+      final OptionalInt minIndex = bins.stream().mapToInt(Bin::getIndex).min();
+      if (!minIndex.isPresent()) {
+        return bins;
+      }
+      final int upperBound =
+          Integer.MAX_VALUE - maxNumBins < minIndex.getAsInt()
+              ? Integer.MAX_VALUE
+              : minIndex.getAsInt() + maxNumBins - 1;
+      return bins.stream()
+          .map(bin -> new Bin(Math.min(bin.getIndex(), upperBound), bin.getCount()))
+          .collect(Collectors.toList());
+    };
+  }
+
+  public static Stream<Arguments> argStream() {
+    return Arrays.stream(values()).map(Arguments::of);
+  }
+}


### PR DESCRIPTION
As did https://github.com/DataDog/sketches-go/pull/42, this implements a serialization method that is generally faster and produces smaller serialized sketches than the protobuf method.

Here are things that we could work on and that I did not implement as part of this PR:

- add implementations of `Input` and `Output` that are backed by (1) `ByteBuffer`, (2) `java.io.InputStream`/`java.io.OutputStream`
- add specialized implementations of `Store.decodeAndMergeWith()`, especially in `BufferedPaginatedStore` (it should make encoding and decoding more performant).

# Benchmarks

## Serialized size

From https://github.com/DataDog/sketches-go/pull/42.

```
    ddsketch_test.go:513: test case                                      proto custom custom_no_mapping
    ddsketch_test.go:521: dense/empty                                       17     17                 0
    ddsketch_test.go:521: dense/small_int_count                           1116    161               144
    ddsketch_test.go:521: dense/small_non_int_count                       1116    192               175
    ddsketch_test.go:521: sparse/single_value                               31     22                 5
    ddsketch_test.go:521: sparse/small_int_count                            66     30                13
    ddsketch_test.go:521: sparse/log_normal_int_count                    10124   2600              2598
    ddsketch_test.go:521: buffered_paginated/empty                          17     17                 0
    ddsketch_test.go:521: buffered_paginated/single_value                   31     21                 4
    ddsketch_test.go:521: buffered_paginated/small_int_count                66     27                10
    ddsketch_test.go:521: buffered_paginated/small_non_int_count            66    156               139
    ddsketch_test.go:521: buffered_paginated/int_count_linear             6100    866               849
    ddsketch_test.go:521: buffered_paginated/log_normal_int_count        10250   1531              1514
    ddsketch_test.go:521: buffered_paginated/log_normal_non_int_count    10054   6285              6268

```

## Computational cost



```
Benchmark                (count)                (generator)  (sketchOption)  Mode  Cnt   Score   Error  Units
Serialize.toProto         100000                    POISSON       PAGINATED  avgt    3   8.973 ± 3.771  us/op
Serialize.serialize       100000                    POISSON       PAGINATED  avgt    3   3.158 ± 0.164  us/op
Serialize.encode          100000                    POISSON       PAGINATED  avgt    3   2.007 ± 0.067  us/op
Serialize.encodeReusing   100000                    POISSON       PAGINATED  avgt    3   1.581 ± 0.148  us/op
Serialize.toProto         100000  COMPOSITE_POISSON_EXTREME       PAGINATED  avgt    3  44.719 ± 4.861  us/op
Serialize.serialize       100000  COMPOSITE_POISSON_EXTREME       PAGINATED  avgt    3  13.049 ± 0.956  us/op
Serialize.encode          100000  COMPOSITE_POISSON_EXTREME       PAGINATED  avgt    3   5.067 ± 0.301  us/op
Serialize.encodeReusing   100000  COMPOSITE_POISSON_EXTREME       PAGINATED  avgt    3   4.082 ± 0.782  us/op
Serialize.toProto         100000            TRIMODAL_NORMAL       PAGINATED  avgt    3  14.577 ± 2.183  us/op
Serialize.serialize       100000            TRIMODAL_NORMAL       PAGINATED  avgt    3   6.033 ± 0.837  us/op
Serialize.encode          100000            TRIMODAL_NORMAL       PAGINATED  avgt    3   2.278 ± 0.280  us/op
Serialize.encodeReusing   100000            TRIMODAL_NORMAL       PAGINATED  avgt    3   1.502 ± 0.159  us/op
Serialize.toProto         100000                    POISSON        BALANCED  avgt    3   3.655 ± 4.965  us/op
Serialize.serialize       100000                    POISSON        BALANCED  avgt    3   0.999 ± 0.125  us/op
Serialize.encode          100000                    POISSON        BALANCED  avgt    3   1.673 ± 0.213  us/op
Serialize.encodeReusing   100000                    POISSON        BALANCED  avgt    3   1.011 ± 0.155  us/op
Serialize.toProto         100000  COMPOSITE_POISSON_EXTREME        BALANCED  avgt    3   4.986 ± 1.923  us/op
Serialize.serialize       100000  COMPOSITE_POISSON_EXTREME        BALANCED  avgt    3   1.660 ± 0.164  us/op
Serialize.encode          100000  COMPOSITE_POISSON_EXTREME        BALANCED  avgt    3   3.551 ± 0.597  us/op
Serialize.encodeReusing   100000  COMPOSITE_POISSON_EXTREME        BALANCED  avgt    3   2.296 ± 0.145  us/op
Serialize.toProto         100000            TRIMODAL_NORMAL        BALANCED  avgt    3   3.518 ± 1.629  us/op
Serialize.serialize       100000            TRIMODAL_NORMAL        BALANCED  avgt    3   1.102 ± 0.173  us/op
Serialize.encode          100000            TRIMODAL_NORMAL        BALANCED  avgt    3   1.789 ± 0.126  us/op
Serialize.encodeReusing   100000            TRIMODAL_NORMAL        BALANCED  avgt    3   1.273 ± 0.058  us/op
```

There is a significant gain when using the paginated store, likely because the encoding format is closer to the internal representation of the paginated stores (pages can be independently encoded as contiguous counts).

```
Benchmark                  (count)                (generator)  (sketchOption)  Mode  Cnt   Score    Error  Units
Deserialize.fromProto       100000                    POISSON       PAGINATED  avgt    3   8.207 ±  4.893  us/op
Deserialize.decode          100000                    POISSON       PAGINATED  avgt    3   2.990 ±  0.963  us/op
Deserialize.decodeReusing   100000                    POISSON       PAGINATED  avgt    3   1.936 ±  0.344  us/op
Deserialize.fromProto       100000  COMPOSITE_POISSON_EXTREME       PAGINATED  avgt    3  34.745 ± 17.140  us/op
Deserialize.decode          100000  COMPOSITE_POISSON_EXTREME       PAGINATED  avgt    3   5.773 ±  1.660  us/op
Deserialize.decodeReusing   100000  COMPOSITE_POISSON_EXTREME       PAGINATED  avgt    3   5.274 ±  9.821  us/op
Deserialize.fromProto       100000            TRIMODAL_NORMAL       PAGINATED  avgt    3  16.349 ±  4.144  us/op
Deserialize.decode          100000            TRIMODAL_NORMAL       PAGINATED  avgt    3   2.980 ±  0.240  us/op
Deserialize.decodeReusing   100000            TRIMODAL_NORMAL       PAGINATED  avgt    3   2.333 ±  0.335  us/op
Deserialize.fromProto       100000                    POISSON        BALANCED  avgt    3   6.017 ±  2.188  us/op
Deserialize.decode          100000                    POISSON        BALANCED  avgt    3   2.830 ±  1.243  us/op
Deserialize.decodeReusing   100000                    POISSON        BALANCED  avgt    3   1.904 ±  1.352  us/op
Deserialize.fromProto       100000  COMPOSITE_POISSON_EXTREME        BALANCED  avgt    3  13.687 ± 10.720  us/op
Deserialize.decode          100000  COMPOSITE_POISSON_EXTREME        BALANCED  avgt    3   6.769 ±  1.126  us/op
Deserialize.decodeReusing   100000  COMPOSITE_POISSON_EXTREME        BALANCED  avgt    3   4.346 ±  4.982  us/op
Deserialize.fromProto       100000            TRIMODAL_NORMAL        BALANCED  avgt    3   6.772 ±  6.477  us/op
Deserialize.decode          100000            TRIMODAL_NORMAL        BALANCED  avgt    3   3.535 ±  2.058  us/op
Deserialize.decodeReusing   100000            TRIMODAL_NORMAL        BALANCED  avgt    3   2.395 ±  0.628  us/op

```