### PR TITLE
Add indexDelta when encoding contiguous counts

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/BinEncodingMode.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/BinEncodingMode.java
@@ -48,6 +48,7 @@ public enum BinEncodingMode {
    *   <li>[byte] flag
    *   <li>[uvarint64] number of bins N
    *   <li>[varint64] index of first bin
+   *   <li>[varint64] difference between two successive indexes
    *   <li>[varfloat64] count of first bin
    *   <li>[varfloat64] count of second bin
    *   <li>...

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/DenseStore.java
@@ -336,6 +336,7 @@ public abstract class DenseStore implements Store {
     BinEncodingMode.CONTIGUOUS_COUNTS.toFlag(storeFlagType).encode(output);
     VarEncodingHelper.encodeUnsignedVarLong(output, (long) maxIndex - (long) minIndex + 1);
     VarEncodingHelper.encodeSignedVarLong(output, minIndex);
+    VarEncodingHelper.encodeSignedVarLong(output, 1);
     for (int i = minIndex - offset; i <= maxIndex - offset; i++) {
       VarEncodingHelper.encodeVarDouble(output, counts[i]);
     }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/PaginatedStore.java
@@ -433,6 +433,7 @@ public final class PaginatedStore implements Store {
         BinEncodingMode.CONTIGUOUS_COUNTS.toFlag(storeFlagType).encode(output);
         VarEncodingHelper.encodeUnsignedVarLong(output, page.length);
         VarEncodingHelper.encodeSignedVarLong(output, (long) (i + minPageIndex) << PAGE_SHIFT);
+        VarEncodingHelper.encodeSignedVarLong(output, 1);
         for (final double count : page) {
           VarEncodingHelper.encodeVarDouble(output, count);
         }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/Store.java
@@ -194,7 +194,8 @@ public interface Store {
         {
           final long numBins = VarEncodingHelper.decodeUnsignedVarLong(input);
           long index = VarEncodingHelper.decodeSignedVarLong(input);
-          for (long i = 0; i != numBins; i++, index++) {
+          final long indexDelta = VarEncodingHelper.decodeSignedVarLong(input);
+          for (long i = 0; i != numBins; i++, index += indexDelta) {
             final double count = VarEncodingHelper.decodeVarDouble(input);
             add(Math.toIntExact(index), count);
           }


### PR DESCRIPTION
As a follow-up of https://github.com/DataDog/sketches-go/pull/47.

No release has been made since the custom encoding was introduced.