### PR TITLE
Serialize exact summary statistics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 test {
     useJUnitPlatform()
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 spotless {

--- a/src/main/java/com/datadoghq/sketch/WithExactSummaryStatistics.java
+++ b/src/main/java/com/datadoghq/sketch/WithExactSummaryStatistics.java
@@ -38,7 +38,7 @@ public class WithExactSummaryStatistics<QS extends QuantileSketch<QS>>
     this.max = Double.NEGATIVE_INFINITY;
   }
 
-  private WithExactSummaryStatistics(
+  protected WithExactSummaryStatistics(
       QS sketch,
       double count,
       double sum,
@@ -55,35 +55,54 @@ public class WithExactSummaryStatistics<QS extends QuantileSketch<QS>>
     this.max = max;
   }
 
+  protected final QS sketch() {
+    return sketch;
+  }
+
   @Override
   public void accept(double value) {
     sketch.accept(value);
-    count++;
-    simpleSum += value;
-    sumWithCompensation(value);
-    min = Math.min(min, value);
-    max = Math.max(max, value);
+    addToCount(1);
+    addToSum(value);
+    updateMin(value);
+    updateMax(value);
   }
 
   @Override
   public void accept(double value, double count) {
     sketch.accept(value, count);
-    this.count += count;
-    simpleSum += value * count;
-    sumWithCompensation(value * count);
-    min = Math.min(min, value);
-    max = Math.max(max, value);
+    addToCount(count);
+    addToSum(value * count);
+    updateMin(value);
+    updateMax(value);
   }
 
   @Override
   public void mergeWith(WithExactSummaryStatistics<QS> other) {
     sketch.mergeWith(other.sketch);
-    count += other.count;
+    addToCount(other.count);
     simpleSum += other.simpleSum;
     sumWithCompensation(other.sum);
     sumWithCompensation(other.sumCompensation);
     min = Math.min(min, other.min);
     max = Math.max(max, other.max);
+  }
+
+  protected final void addToCount(double addend) {
+    count += addend;
+  }
+
+  protected final void addToSum(double addend) {
+    simpleSum += addend;
+    sumWithCompensation(addend);
+  }
+
+  protected final void updateMin(double value) {
+    min = Math.min(min, value);
+  }
+
+  protected final void updateMax(double value) {
+    max = Math.max(max, value);
   }
 
   private void sumWithCompensation(double value) {
@@ -141,6 +160,26 @@ public class WithExactSummaryStatistics<QS extends QuantileSketch<QS>>
     if (count == 0) {
       throw new NoSuchElementException();
     }
+    return max;
+  }
+
+  protected final double sum() {
+    return sum;
+  }
+
+  protected final double sumCompensation() {
+    return sumCompensation;
+  }
+
+  protected final double simpleSum() {
+    return simpleSum;
+  }
+
+  protected final double min() {
+    return min;
+  }
+
+  protected final double max() {
     return max;
   }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/DDSketchWithExactSummaryStatistics.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/DDSketchWithExactSummaryStatistics.java
@@ -1,0 +1,116 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch;
+
+import com.datadoghq.sketch.WithExactSummaryStatistics;
+import com.datadoghq.sketch.ddsketch.encoding.Flag;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
+import com.datadoghq.sketch.ddsketch.encoding.Output;
+import com.datadoghq.sketch.ddsketch.encoding.VarEncodingHelper;
+import com.datadoghq.sketch.ddsketch.mapping.IndexMapping;
+import com.datadoghq.sketch.ddsketch.store.Store;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+public class DDSketchWithExactSummaryStatistics extends WithExactSummaryStatistics<DDSketch> {
+
+  public DDSketchWithExactSummaryStatistics(Supplier<DDSketch> ddSketchConstructor) {
+    super(ddSketchConstructor);
+  }
+
+  private DDSketchWithExactSummaryStatistics(
+      DDSketch sketch,
+      double count,
+      double sum,
+      double sumCompensation,
+      double simpleSum,
+      double min,
+      double max) {
+    super(sketch, count, sum, sumCompensation, simpleSum, min, max);
+  }
+
+  @Override
+  public DDSketchWithExactSummaryStatistics copy() {
+    return new DDSketchWithExactSummaryStatistics(
+        sketch().copy(), getCount(), sum(), sumCompensation(), simpleSum(), min(), max());
+  }
+
+  public void encode(Output output, boolean omitIndexMapping) throws IOException {
+    final double count = getCount();
+    if (count != 0) {
+      Flag.COUNT.encode(output);
+      VarEncodingHelper.encodeVarDouble(output, count);
+      Flag.MIN.encode(output);
+      output.writeDoubleLE(getMinValue());
+      Flag.MAX.encode(output);
+      output.writeDoubleLE(getMaxValue());
+    }
+    final double sum = getSum();
+    if (sum != 0) {
+      Flag.SUM.encode(output);
+      output.writeDoubleLE(sum);
+    }
+    sketch().encode(output, omitIndexMapping);
+  }
+
+  public void decodeAndMergeWith(Input input) throws IOException {
+    sketch().decodeAndMergeWith(input, this::decodeSummaryStatistic);
+  }
+
+  public static DDSketchWithExactSummaryStatistics decode(
+      Input input, Supplier<Store> storeSupplier) throws IOException {
+    return decode(input, storeSupplier, null);
+  }
+
+  public static DDSketchWithExactSummaryStatistics decode(
+      Input input, Supplier<Store> storeSupplier, IndexMapping indexMapping) throws IOException {
+    final DecodingState state = new DecodingState();
+    final DDSketch sketch =
+        DDSketch.decode(input, storeSupplier, indexMapping, state::decodeSummaryStatistic);
+    // It is assumed that if the count is encoded, other exact summary statistics are encoded as
+    // well, which is the case if encode() is used.
+    if (state.count == 0 && !sketch.isEmpty()) {
+      throw new IllegalArgumentException("The exact summary statistics are missing.");
+    }
+    return new DDSketchWithExactSummaryStatistics(
+        sketch, state.count, state.sum, 0, state.sum, state.min, state.max);
+  }
+
+  private void decodeSummaryStatistic(Input input, Flag flag) throws IOException {
+    if (Flag.COUNT.equals(flag)) {
+      addToCount(VarEncodingHelper.decodeVarDouble(input));
+    } else if (Flag.SUM.equals(flag)) {
+      addToSum(input.readDoubleLE());
+    } else if (Flag.MIN.equals(flag)) {
+      updateMin(input.readDoubleLE());
+    } else if (Flag.MAX.equals(flag)) {
+      updateMax(input.readDoubleLE());
+    } else {
+      DDSketch.throwInvalidFlagException(input, flag);
+    }
+  }
+
+  private static final class DecodingState {
+    private double count = 0;
+    private double sum = 0;
+    private double min = Double.POSITIVE_INFINITY;
+    private double max = Double.NEGATIVE_INFINITY;
+
+    private void decodeSummaryStatistic(Input input, Flag flag) throws IOException {
+      if (Flag.COUNT.equals(flag)) {
+        count += VarEncodingHelper.decodeVarDouble(input);
+      } else if (Flag.SUM.equals(flag)) {
+        sum += input.readDoubleLE();
+      } else if (Flag.MIN.equals(flag)) {
+        min = Math.min(min, input.readDoubleLE());
+      } else if (Flag.MAX.equals(flag)) {
+        max = Math.max(max, input.readDoubleLE());
+      } else {
+        DDSketch.throwInvalidFlagException(input, flag);
+      }
+    }
+  }
+}

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Flag.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/Flag.java
@@ -51,6 +51,54 @@ public final class Flag {
    */
   public static final Flag ZERO_COUNT = new Flag(Type.SKETCH_FEATURES, (byte) 1);
 
+  /**
+   * Encodes the total count.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[varfloat64] total count
+   * </ul>
+   */
+  public static final Flag COUNT = new Flag(Type.SKETCH_FEATURES, (byte) 0x28);
+
+  /**
+   * Encodes the total sum.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] total sum
+   * </ul>
+   */
+  public static final Flag SUM = new Flag(Type.SKETCH_FEATURES, (byte) 0x21);
+
+  /**
+   * Encodes the global minimum value.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] global minimum value
+   * </ul>
+   */
+  public static final Flag MIN = new Flag(Type.SKETCH_FEATURES, (byte) 0x22);
+
+  /**
+   * Encodes the global maximum value.
+   *
+   * <p>Encoding format:
+   *
+   * <ul>
+   *   <li>[byte] flag
+   *   <li>[float64LE] global maximum value
+   * </ul>
+   */
+  public static final Flag MAX = new Flag(Type.SKETCH_FEATURES, (byte) 0x23);
+
   private final byte marker;
 
   private Flag(byte marker) {

--- a/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
@@ -43,6 +43,10 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
 
   protected abstract void assertAverageAccurate(double[] values, double actualAverageValue);
 
+  protected void assertCountAccurate(double[] values, double actualCountValue) {
+    assertThat(actualCountValue).isCloseTo(values.length, DOUBLE_OFFSET);
+  }
+
   @Test
   protected void throwsExceptionWhenExpected() {
 
@@ -106,7 +110,7 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
   }
 
   protected final void assertEncodes(boolean merged, double[] values, QS sketch) {
-    assertThat(sketch.getCount()).isCloseTo(values.length, DOUBLE_OFFSET);
+    assertCountAccurate(values, sketch.getCount());
     if (values.length == 0) {
       assertTrue(sketch.isEmpty());
     } else {

--- a/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/QuantileSketchTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.datadoghq.sketch.util.accuracy.AccuracyTester;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
@@ -38,9 +39,9 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
 
   protected abstract void assertMaxAccurate(double[] sortedValues, double actualMaxValue);
 
-  protected abstract void assertSumAccurate(double[] sortedValues, double actualSumValue);
+  protected abstract void assertSumAccurate(double[] values, double actualSumValue);
 
-  protected abstract void assertAverageAccurate(double[] sortedValues, double actualAverageValue);
+  protected abstract void assertAverageAccurate(double[] values, double actualAverageValue);
 
   @Test
   protected void throwsExceptionWhenExpected() {
@@ -146,9 +147,11 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
     }
     {
       final QS sketch = newSketch();
+      // Use LinkedHashMap to maintain order.
       Arrays.stream(values)
           .boxed()
-          .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()))
+          .collect(
+              Collectors.groupingBy(Function.identity(), LinkedHashMap::new, Collectors.counting()))
           .forEach(sketch::accept);
       test(false, values, sketch);
     }
@@ -198,6 +201,26 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
   }
 
   @Test
+  void testNegativeConstants() {
+    testAdding(0);
+    testAdding(-1);
+    testAdding(-1, -1, -1);
+    testAdding(-10, -10, -10);
+    testAdding(IntStream.range(0, 10000).mapToDouble(i -> -2).toArray());
+    testAdding(-10, -10, -11, -11, -11);
+  }
+
+  @Test
+  void testNegativeAndPositiveConstants() {
+    testAdding(0);
+    testAdding(-1, 1);
+    testAdding(-1, -1, -1, 1, 1, 1);
+    testAdding(-10, -10, -10, 10, 10, 10);
+    testAdding(IntStream.range(0, 20000).mapToDouble(i -> i % 2 == 0 ? 2 : -2).toArray());
+    testAdding(-10, -10, -11, -11, -11, 10, 10, 11, 11, 11);
+  }
+
+  @Test
   void testSingleValue() {
 
     testAdding(0);
@@ -221,12 +244,30 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
                 IntStream.range(0, 100).mapToDouble(i -> i),
                 IntStream.range(0, 10).mapToDouble(i -> 0))
             .toArray());
+
+    testAdding(
+        DoubleStream.concat(
+                IntStream.range(0, 10).mapToDouble(i -> 0),
+                IntStream.range(-100, 100).mapToDouble(i -> i))
+            .toArray());
+
+    testAdding(
+        DoubleStream.concat(
+                IntStream.range(-100, 100).mapToDouble(i -> i),
+                IntStream.range(0, 10).mapToDouble(i -> 0))
+            .toArray());
   }
 
   @Test
   void testWithoutZeros() {
 
     testAdding(IntStream.range(1, 100).mapToDouble(i -> i).toArray());
+
+    testAdding(
+        DoubleStream.concat(
+                IntStream.range(-100, -1).mapToDouble(i -> i),
+                IntStream.range(1, 100).mapToDouble(i -> i))
+            .toArray());
   }
 
   @Test
@@ -240,6 +281,26 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
   }
 
   @Test
+  void testNegativeNumbersIncreasingLinearly() {
+    testAdding(IntStream.range(-10000, 0).mapToDouble(v -> v).toArray());
+  }
+
+  @Test
+  void testNegativeAndPositiveNumbersIncreasingLinearly() {
+    testAdding(IntStream.range(-10000, 10000).mapToDouble(v -> v).toArray());
+  }
+
+  @Test
+  void testNegativeNumbersDecreasingLinearly() {
+    testAdding(IntStream.range(0, 10000).mapToDouble(v -> -v).toArray());
+  }
+
+  @Test
+  void testNegativeAndPositiveNumbersDecreasingLinearly() {
+    testAdding(IntStream.range(0, 20000).mapToDouble(v -> 10000 - v).toArray());
+  }
+
+  @Test
   void testIncreasingExponentially() {
     testAdding(IntStream.range(0, 100).mapToDouble(Math::exp).toArray());
   }
@@ -247,6 +308,34 @@ public abstract class QuantileSketchTest<QS extends QuantileSketch<QS>> {
   @Test
   void testDecreasingExponentially() {
     testAdding(IntStream.range(0, 100).mapToDouble(i -> Math.exp(-i)).toArray());
+  }
+
+  @Test
+  void testNegativeNumbersIncreasingExponentially() {
+    testAdding(IntStream.range(0, 100).mapToDouble(i -> -Math.exp(i)).toArray());
+  }
+
+  @Test
+  void testNegativeAndPositiveNumbersIncreasingExponentially() {
+    testAdding(
+        DoubleStream.concat(
+                IntStream.range(0, 100).mapToDouble(i -> -Math.exp(i)),
+                IntStream.range(0, 100).mapToDouble(Math::exp))
+            .toArray());
+  }
+
+  @Test
+  void testNegativeNumbersDecreasingExponentially() {
+    testAdding(IntStream.range(0, 100).mapToDouble(i -> -Math.exp(-i)).toArray());
+  }
+
+  @Test
+  void testNegativeAndPositiveNumbersDecreasingExponentially() {
+    testAdding(
+        DoubleStream.concat(
+                IntStream.range(0, 100).mapToDouble(i -> -Math.exp(-i)),
+                IntStream.range(0, 100).mapToDouble(i -> Math.exp(-i)))
+            .toArray());
   }
 
   @Test

--- a/src/test/java/com/datadoghq/sketch/WithExactSummaryStatisticsTest.java
+++ b/src/test/java/com/datadoghq/sketch/WithExactSummaryStatisticsTest.java
@@ -12,9 +12,12 @@ import java.util.DoubleSummaryStatistics;
 import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Assertions;
 
-public class WithExactSummaryStatisticsTest
-    extends QuantileSketchTest<
-        WithExactSummaryStatistics<WithExactSummaryStatisticsTest.DummySketch>> {
+public abstract class WithExactSummaryStatisticsTest<
+        QS extends QuantileSketch<QS>, W extends WithExactSummaryStatistics<QS>>
+    extends QuantileSketchTest<WithExactSummaryStatistics<QS>> {
+
+  @Override
+  protected abstract W newSketch();
 
   static class DummySketch implements QuantileSketch<DummySketch> {
 
@@ -108,17 +111,6 @@ public class WithExactSummaryStatisticsTest
   }
 
   @Override
-  protected WithExactSummaryStatistics<DummySketch> newSketch() {
-    return new WithExactSummaryStatistics<>(DummySketch::new);
-  }
-
-  @Override
-  protected void assertQuantileAccurate(
-      boolean merged, double[] sortedValues, double quantile, double actualQuantileValue) {
-    // Nothing to assert
-  }
-
-  @Override
   protected void assertMinAccurate(double[] sortedValues, double actualMinValue) {
     assertEquals(sortedValues[0], actualMinValue);
   }
@@ -142,5 +134,20 @@ public class WithExactSummaryStatisticsTest
     final DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
     Arrays.stream(values).forEach(summaryStatistics);
     return summaryStatistics;
+  }
+
+  static class DummySketchWithExactSummaryStatistics
+      extends WithExactSummaryStatisticsTest<DummySketch, WithExactSummaryStatistics<DummySketch>> {
+
+    @Override
+    protected WithExactSummaryStatistics<DummySketch> newSketch() {
+      return new WithExactSummaryStatistics<>(DummySketch::new);
+    }
+
+    @Override
+    protected void assertQuantileAccurate(
+        boolean merged, double[] sortedValues, double quantile, double actualQuantileValue) {
+      // Nothing to assert
+    }
   }
 }

--- a/src/test/java/com/datadoghq/sketch/WithExactSummaryStatisticsTest.java
+++ b/src/test/java/com/datadoghq/sketch/WithExactSummaryStatisticsTest.java
@@ -129,16 +129,18 @@ public class WithExactSummaryStatisticsTest
   }
 
   @Override
-  protected void assertSumAccurate(double[] sortedValues, double actualSumValue) {
-    final DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
-    Arrays.stream(sortedValues).forEach(summaryStatistics);
-    assertEquals(summaryStatistics.getSum(), actualSumValue);
+  protected void assertSumAccurate(double[] values, double actualSumValue) {
+    assertEquals(summaryStatistics(values).getSum(), actualSumValue);
   }
 
   @Override
-  protected void assertAverageAccurate(double[] sortedValues, double actualAverageValue) {
+  protected void assertAverageAccurate(double[] values, double actualAverageValue) {
+    assertEquals(summaryStatistics(values).getAverage(), actualAverageValue);
+  }
+
+  private static DoubleSummaryStatistics summaryStatistics(double[] values) {
     final DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
-    Arrays.stream(sortedValues).forEach(summaryStatistics);
-    assertEquals(summaryStatistics.getAverage(), actualAverageValue);
+    Arrays.stream(values).forEach(summaryStatistics);
+    return summaryStatistics;
   }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchTest.java
@@ -54,13 +54,17 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
   @Override
   protected void assertQuantileAccurate(
       boolean merged, double[] sortedValues, double quantile, double actualQuantileValue) {
+    assertQuantileAccurate(sortedValues, quantile, actualQuantileValue, relativeAccuracy());
+  }
 
+  static void assertQuantileAccurate(
+      double[] sortedValues, double quantile, double actualQuantileValue, double relativeAccuracy) {
     final double lowerQuantileValue =
         sortedValues[(int) Math.floor(quantile * (sortedValues.length - 1))];
     final double upperQuantileValue =
         sortedValues[(int) Math.ceil(quantile * (sortedValues.length - 1))];
 
-    assertAccurate(lowerQuantileValue, upperQuantileValue, actualQuantileValue);
+    assertAccurate(lowerQuantileValue, upperQuantileValue, actualQuantileValue, relativeAccuracy);
   }
 
   @Override
@@ -90,14 +94,19 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
   }
 
   private void assertAccurate(double minExpected, double maxExpected, double actual) {
+    assertAccurate(minExpected, maxExpected, actual, relativeAccuracy());
+  }
+
+  private static void assertAccurate(
+      double minExpected, double maxExpected, double actual, double relativeAccuracy) {
     final double relaxedMinExpected =
         minExpected > 0
-            ? minExpected * (1 - relativeAccuracy())
-            : minExpected * (1 + relativeAccuracy());
+            ? minExpected * (1 - relativeAccuracy)
+            : minExpected * (1 + relativeAccuracy);
     final double relaxedMaxExpected =
         maxExpected > 0
-            ? maxExpected * (1 + relativeAccuracy())
-            : maxExpected * (1 - relativeAccuracy());
+            ? maxExpected * (1 + relativeAccuracy)
+            : maxExpected * (1 - relativeAccuracy);
 
     if (actual < relaxedMinExpected - AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR
         || actual > relaxedMaxExpected + AccuracyTester.FLOATING_POINT_ACCEPTABLE_ERROR) {
@@ -107,101 +116,6 @@ abstract class DDSketchTest extends QuantileSketchTest<DDSketch> {
 
   private void assertAccurate(double expected, double actual) {
     assertAccurate(expected, expected, actual);
-  }
-
-  @Test
-  void testNegativeConstants() {
-    testAdding(0);
-    testAdding(-1);
-    testAdding(-1, -1, -1);
-    testAdding(-10, -10, -10);
-    testAdding(IntStream.range(0, 10000).mapToDouble(i -> -2).toArray());
-    testAdding(-10, -10, -11, -11, -11);
-  }
-
-  @Test
-  void testNegativeAndPositiveConstants() {
-    testAdding(0);
-    testAdding(-1, 1);
-    testAdding(-1, -1, -1, 1, 1, 1);
-    testAdding(-10, -10, -10, 10, 10, 10);
-    testAdding(IntStream.range(0, 20000).mapToDouble(i -> i % 2 == 0 ? 2 : -2).toArray());
-    testAdding(-10, -10, -11, -11, -11, 10, 10, 11, 11, 11);
-  }
-
-  @Test
-  void testWithZeros() {
-
-    testAdding(IntStream.range(0, 100).mapToDouble(i -> 0).toArray());
-
-    testAdding(
-        DoubleStream.concat(
-                IntStream.range(0, 10).mapToDouble(i -> 0),
-                IntStream.range(-100, 100).mapToDouble(i -> i))
-            .toArray());
-
-    testAdding(
-        DoubleStream.concat(
-                IntStream.range(-100, 100).mapToDouble(i -> i),
-                IntStream.range(0, 10).mapToDouble(i -> 0))
-            .toArray());
-  }
-
-  @Test
-  void testWithoutZeros() {
-    testAdding(
-        DoubleStream.concat(
-                IntStream.range(-100, -1).mapToDouble(i -> i),
-                IntStream.range(1, 100).mapToDouble(i -> i))
-            .toArray());
-  }
-
-  @Test
-  void testNegativeNumbersIncreasingLinearly() {
-    testAdding(IntStream.range(-10000, 0).mapToDouble(v -> v).toArray());
-  }
-
-  @Test
-  void testNegativeAndPositiveNumbersIncreasingLinearly() {
-    testAdding(IntStream.range(-10000, 10000).mapToDouble(v -> v).toArray());
-  }
-
-  @Test
-  void testNegativeNumbersDecreasingLinearly() {
-    testAdding(IntStream.range(0, 10000).mapToDouble(v -> -v).toArray());
-  }
-
-  @Test
-  void testNegativeAndPositiveNumbersDecreasingLinearly() {
-    testAdding(IntStream.range(0, 20000).mapToDouble(v -> 10000 - v).toArray());
-  }
-
-  @Test
-  void testNegativeNumbersIncreasingExponentially() {
-    testAdding(IntStream.range(0, 100).mapToDouble(i -> -Math.exp(i)).toArray());
-  }
-
-  @Test
-  void testNegativeAndPositiveNumbersIncreasingExponentially() {
-    testAdding(
-        DoubleStream.concat(
-                IntStream.range(0, 100).mapToDouble(i -> -Math.exp(i)),
-                IntStream.range(0, 100).mapToDouble(Math::exp))
-            .toArray());
-  }
-
-  @Test
-  void testNegativeNumbersDecreasingExponentially() {
-    testAdding(IntStream.range(0, 100).mapToDouble(i -> -Math.exp(-i)).toArray());
-  }
-
-  @Test
-  void testNegativeAndPositiveNumbersDecreasingExponentially() {
-    testAdding(
-        DoubleStream.concat(
-                IntStream.range(0, 100).mapToDouble(i -> -Math.exp(-i)),
-                IntStream.range(0, 100).mapToDouble(i -> Math.exp(-i)))
-            .toArray());
   }
 
   @Override

--- a/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchWithExactSummaryStatisticsTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/DDSketchWithExactSummaryStatisticsTest.java
@@ -1,0 +1,186 @@
+/* Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2021 Datadog, Inc.
+ */
+
+package com.datadoghq.sketch.ddsketch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.datadoghq.sketch.WithExactSummaryStatistics;
+import com.datadoghq.sketch.WithExactSummaryStatisticsTest;
+import com.datadoghq.sketch.ddsketch.encoding.ByteArrayInput;
+import com.datadoghq.sketch.ddsketch.encoding.GrowingByteArrayOutput;
+import com.datadoghq.sketch.ddsketch.encoding.Input;
+import com.datadoghq.sketch.ddsketch.mapping.IndexMapping;
+import com.datadoghq.sketch.ddsketch.mapping.LogarithmicMapping;
+import com.datadoghq.sketch.ddsketch.store.Store;
+import com.datadoghq.sketch.ddsketch.store.StoreTestCase;
+import com.datadoghq.sketch.ddsketch.store.UnboundedSizeDenseStore;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+public abstract class DDSketchWithExactSummaryStatisticsTest
+    extends WithExactSummaryStatisticsTest<DDSketch, DDSketchWithExactSummaryStatistics> {
+
+  abstract double relativeAccuracy();
+
+  IndexMapping mapping() {
+    return new LogarithmicMapping(relativeAccuracy());
+  }
+
+  Supplier<Store> storeSupplier() {
+    return UnboundedSizeDenseStore::new;
+  }
+
+  @Override
+  protected DDSketchWithExactSummaryStatistics newSketch() {
+    return new DDSketchWithExactSummaryStatistics(() -> new DDSketch(mapping(), storeSupplier()));
+  }
+
+  @Override
+  protected void assertQuantileAccurate(
+      boolean merged, double[] sortedValues, double quantile, double actualQuantileValue) {
+    DDSketchTest.assertQuantileAccurate(
+        sortedValues, quantile, actualQuantileValue, relativeAccuracy());
+  }
+
+  @Override
+  protected void test(
+      boolean merged, double[] values, WithExactSummaryStatistics<DDSketch> sketch) {
+    assertEncodes(merged, values, sketch);
+    testEncodeDecode(merged, values, (DDSketchWithExactSummaryStatistics) sketch);
+  }
+
+  void testEncodeDecode(
+      boolean merged,
+      double[] values,
+      DDSketchWithExactSummaryStatistics sketch,
+      Supplier<Store> finalStoreSupplier) {
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
+    try {
+      sketch.encode(output, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    { // DDSketchWithExactSummaryStatistics -> encoded -> DDSketchWithExactSummaryStatistics
+      final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
+      final DDSketchWithExactSummaryStatistics decoded;
+      try {
+        decoded = DDSketchWithExactSummaryStatistics.decode(input, finalStoreSupplier);
+        assertThat(input.hasRemaining()).isFalse();
+      } catch (IOException e) {
+        fail(e);
+        return;
+      }
+      assertEncodes(merged, values, decoded);
+    }
+    { // DDSketchWithExactSummaryStatistics -> encoded -> DDSketch (exact summary statistics are
+      // lost)
+      final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
+      final DDSketch decoded;
+      try {
+        decoded = DDSketch.decode(input, finalStoreSupplier);
+        assertThat(input.hasRemaining()).isFalse();
+      } catch (IOException e) {
+        fail(e);
+        return;
+      }
+      assertCountAccurate(values, decoded.getCount());
+    }
+  }
+
+  void testEncodeDecode(
+      boolean merged, double[] values, DDSketchWithExactSummaryStatistics sketch) {
+    Arrays.stream(StoreTestCase.values())
+        .filter(StoreTestCase::isLossless)
+        .forEach(
+            storeTestCase ->
+                testEncodeDecode(merged, values, sketch, storeTestCase.storeSupplier()));
+  }
+
+  @Test
+  void testDecodeAndMergeWith() {
+    final double[] values = new double[] {0.33, -7};
+    final DDSketchWithExactSummaryStatistics sketch0 = newSketch();
+    final DDSketchWithExactSummaryStatistics sketch1 = newSketch();
+    sketch0.accept(values[0]);
+    sketch1.accept(values[1]);
+    final GrowingByteArrayOutput output0 = GrowingByteArrayOutput.withDefaultInitialCapacity();
+    final GrowingByteArrayOutput output1 = GrowingByteArrayOutput.withDefaultInitialCapacity();
+    try {
+      sketch0.encode(output0, false);
+      sketch1.encode(output1, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input0 = ByteArrayInput.wrap(output0.backingArray(), 0, output0.numWrittenBytes());
+    final Input input1 = ByteArrayInput.wrap(output1.backingArray(), 0, output1.numWrittenBytes());
+    final DDSketchWithExactSummaryStatistics decoded;
+    try {
+      decoded = DDSketchWithExactSummaryStatistics.decode(input0, storeSupplier());
+      decoded.decodeAndMergeWith(input1);
+      assertThat(input0.hasRemaining()).isFalse();
+      assertThat(input1.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertEncodes(true, values, decoded);
+  }
+
+  @Test
+  void testMergingByConcatenatingEncoded() {
+    final double[] values = new double[] {0.33, -7};
+    final DDSketchWithExactSummaryStatistics sketch0 = newSketch();
+    final DDSketchWithExactSummaryStatistics sketch1 = newSketch();
+    sketch0.accept(values[0]);
+    sketch1.accept(values[1]);
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
+    try {
+      sketch0.encode(output, false);
+      sketch1.encode(output, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
+    final DDSketchWithExactSummaryStatistics decoded;
+    try {
+      decoded = DDSketchWithExactSummaryStatistics.decode(input, storeSupplier());
+      assertThat(input.hasRemaining()).isFalse();
+    } catch (IOException e) {
+      fail(e);
+      return;
+    }
+    assertEncodes(true, values, decoded);
+  }
+
+  @Test
+  void testMissingExactSummaryStatistics() {
+    final double[] values = new double[] {0.33, -7};
+    final DDSketch sketch = new DDSketch(mapping(), storeSupplier());
+    Arrays.stream(values).forEach(sketch);
+    final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
+    try {
+      sketch.encode(output, false);
+    } catch (IOException e) {
+      fail(e);
+    }
+    final Input input = ByteArrayInput.wrap(output.backingArray(), 0, output.numWrittenBytes());
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> DDSketchWithExactSummaryStatistics.decode(input, storeSupplier()));
+  }
+
+  static class DDSketchTestWithExactSummaryStatistics1
+      extends DDSketchWithExactSummaryStatisticsTest {
+
+    @Override
+    double relativeAccuracy() {
+      return 1e-1;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the logic to serialize exact summary statistics, similarly to what was done in https://github.com/DataDog/sketches-go/pull/44.