### PR TITLE
Use the most space-efficient encoding for dense stores

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
@@ -12,6 +12,37 @@ public final class VarEncodingHelper {
   private static final int MAX_VAR_LEN_64 = 9;
   private static final int VAR_DOUBLE_ROTATE_DISTANCE = 6;
 
+  private static final byte[] UNSIGNED_VAR_LONG_LENGTHS = new byte[65];
+  private static final byte[] VAR_DOUBLE_LENGTHS = new byte[65];
+
+  static {
+    final GrowingByteArrayOutput output =
+        GrowingByteArrayOutput.withInitialCapacity(MAX_VAR_LEN_64);
+
+    for (int numLeadingZeros = 0; numLeadingZeros <= 64; numLeadingZeros++) {
+      output.clear();
+      try {
+        encodeUnsignedVarLong(output, numLeadingZeros == 64 ? 0L : -1L >>> numLeadingZeros);
+      } catch (IOException e) {
+        // Propagate the exception.
+        throw new RuntimeException(e);
+      }
+      UNSIGNED_VAR_LONG_LENGTHS[numLeadingZeros] = (byte) output.trimmedCopy().length;
+    }
+
+    for (int numTrailingZeros = 0; numTrailingZeros <= 64; numTrailingZeros++) {
+      output.clear();
+      try {
+        encodeVarDouble(
+            output, varBitsToDouble(numTrailingZeros == 64 ? 0L : -1L << numTrailingZeros));
+      } catch (IOException e) {
+        // Propagate the exception.
+        throw new RuntimeException(e);
+      }
+      VAR_DOUBLE_LENGTHS[numTrailingZeros] = (byte) output.trimmedCopy().length;
+    }
+  }
+
   private VarEncodingHelper() {}
 
   /**
@@ -54,6 +85,18 @@ public final class VarEncodingHelper {
   }
 
   /**
+   * {@code unsignedVarLongEncodedLength} returns the number of bytes that {@link
+   * #encodeUnsignedVarLong(Output, long)} encodes a {@code long} value into.
+   *
+   * @param value the value to encode
+   * @return the number of bytes that {@link #encodeUnsignedVarLong(Output, long)} encodes a {@code
+   *     long} value into
+   */
+  public static byte unsignedVarLongEncodedLength(long value) {
+    return UNSIGNED_VAR_LONG_LENGTHS[Long.numberOfLeadingZeros(value)];
+  }
+
+  /**
    * {@code encodeSignedVarLong} serializes {@code long} values using zig-zag encoding, which
    * ensures small-scale integers are turned into integers that have leading zeros, whether they are
    * positive or negative, hence allows for space-efficient encoding of those values.
@@ -63,7 +106,7 @@ public final class VarEncodingHelper {
    * @throws IOException if an {@link IOException} is thrown while writing to {@code output}
    */
   public static void encodeSignedVarLong(final Output output, final long value) throws IOException {
-    encodeUnsignedVarLong(output, (value >> (64 - 1) ^ (value << 1)));
+    encodeUnsignedVarLong(output, zigZagEncode(value));
   }
 
   /**
@@ -75,7 +118,26 @@ public final class VarEncodingHelper {
    * @throws IOException if an {@link IOException} is thrown while reading from {@code input}
    */
   public static long decodeSignedVarLong(final Input input) throws IOException {
-    final long value = decodeUnsignedVarLong(input);
+    return zigZagDecode(decodeUnsignedVarLong(input));
+  }
+
+  /**
+   * {@code signedVarLongEncodedLength} returns the number of bytes that {@link
+   * #encodeSignedVarLong(Output, long)} encodes a {@code long} value into.
+   *
+   * @param value the value to encode
+   * @return the number of bytes that {@link #encodeSignedVarLong(Output, long)} encodes a {@code
+   *     long} value into
+   */
+  public static byte signedVarLongEncodedLength(long value) {
+    return UNSIGNED_VAR_LONG_LENGTHS[Long.numberOfLeadingZeros(zigZagEncode(value))];
+  }
+
+  private static long zigZagEncode(long value) {
+    return value >> (64 - 1) ^ (value << 1);
+  }
+
+  private static long zigZagDecode(long value) {
     return (value >>> 1) ^ -(value & 1);
   }
 
@@ -102,10 +164,7 @@ public final class VarEncodingHelper {
    * @throws IOException if an {@link IOException} is thrown while writing to {@code output}
    */
   public static void encodeVarDouble(final Output output, final double value) throws IOException {
-    long bits =
-        Long.rotateLeft(
-            Double.doubleToRawLongBits(value + 1) - Double.doubleToRawLongBits(1),
-            VAR_DOUBLE_ROTATE_DISTANCE);
+    long bits = doubleToVarBits(value);
     for (int i = 0; i < MAX_VAR_LEN_64 - 1; i++) {
       final byte next = (byte) (bits >>> (8 * 8 - 7));
       bits <<= 7;
@@ -140,6 +199,28 @@ public final class VarEncodingHelper {
       }
       bits |= ((long) next & 0x7FL) << shift;
     }
+    return varBitsToDouble(bits);
+  }
+
+  /**
+   * {@code varDoubleEncodedLength} returns the number of bytes that {@link #encodeVarDouble(Output,
+   * double)} encodes a {@code double} value into.
+   *
+   * @param value the value to encode
+   * @return the number of bytes that {@link #encodeVarDouble(Output, double)} encodes a {@code
+   *     double} value into
+   */
+  public static byte varDoubleEncodedLength(double value) {
+    return VAR_DOUBLE_LENGTHS[Long.numberOfTrailingZeros(doubleToVarBits(value))];
+  }
+
+  private static long doubleToVarBits(double value) {
+    return Long.rotateLeft(
+        Double.doubleToRawLongBits(value + 1) - Double.doubleToRawLongBits(1),
+        VAR_DOUBLE_ROTATE_DISTANCE);
+  }
+
+  private static double varBitsToDouble(long bits) {
     return Double.longBitsToDouble(
             Long.rotateRight(bits, VAR_DOUBLE_ROTATE_DISTANCE) + Double.doubleToRawLongBits(1))
         - 1;

--- a/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelper.java
@@ -16,6 +16,12 @@ public final class VarEncodingHelper {
   private static final byte[] VAR_DOUBLE_LENGTHS = new byte[65];
 
   static {
+    // unsignedVarLongEncodedLength, signedVarLongEncodedLength and varDoubleEncodedLength can
+    // compute their outputs from the number of leading or trailing zeros in the binary
+    // representations of their inputs (possibly after a few bitwise operations).
+    // Those encoded lengths are precomputed once for all for any possible number of leading or
+    // trailing zeros, and are stored in UNSIGNED_VAR_LONG_LENGTHS and VAR_DOUBLE_LENGTHS.
+
     final GrowingByteArrayOutput output =
         GrowingByteArrayOutput.withInitialCapacity(MAX_VAR_LEN_64);
 

--- a/src/test/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelperTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/encoding/VarEncodingHelperTest.java
@@ -44,6 +44,12 @@ class VarEncodingHelperTest {
     assertThat(decoded).isEqualTo(value);
   }
 
+  @ParameterizedTest
+  @MethodSource("unsignedVarLongs")
+  void testUnsignedVarLongEncodedLength(long value, byte[] bytes) {
+    assertThat((int) VarEncodingHelper.unsignedVarLongEncodedLength(value)).isEqualTo(bytes.length);
+  }
+
   static Stream<Arguments> unsignedVarLongs() {
     return Stream.of(
         arguments(0L, new byte[] {0x00}),
@@ -109,6 +115,12 @@ class VarEncodingHelperTest {
       return;
     }
     assertThat(decoded).isEqualTo(value);
+  }
+
+  @ParameterizedTest
+  @MethodSource("signedVarLongs")
+  void testSignedVarLongEncodedLength(long value, byte[] bytes) {
+    assertThat((int) VarEncodingHelper.signedVarLongEncodedLength(value)).isEqualTo(bytes.length);
   }
 
   static Stream<Arguments> signedVarLongs() {
@@ -289,6 +301,12 @@ class VarEncodingHelperTest {
       return;
     }
     assertThat(decoded).isEqualTo(value);
+  }
+
+  @ParameterizedTest
+  @MethodSource("varDoubles")
+  void testVarDoubleEncodedLength(double value, byte[] bytes) {
+    assertThat((int) VarEncodingHelper.varDoubleEncodedLength(value)).isEqualTo(bytes.length);
   }
 
   static Stream<Arguments> varDoubles() {


### PR DESCRIPTION
When serializing a dense store with the custom encoding, figure out if the data would be more space-efficiently encoded densely or sparsely, and use the better option.

This is similar to what was done in https://github.com/DataDog/sketches-go/pull/53.

# Benchmark

As in the Go implementation, there is a computational cost. See the benchmarks in https://github.com/DataDog/sketches-go/pull/53 for the gain in space efficiency.

## Before

```
Serialize.encode          100000                    POISSON                0.01            FAST  NANOSECONDS  avgt    3  2.617 ± 0.748  us/op
Serialize.encode          100000  COMPOSITE_POISSON_EXTREME                0.01            FAST  NANOSECONDS  avgt    3  4.877 ± 5.788  us/op
Serialize.encode          100000            TRIMODAL_NORMAL                0.01            FAST  NANOSECONDS  avgt    3  3.995 ± 1.709  us/op
Serialize.encodeReusing   100000                    POISSON                0.01            FAST  NANOSECONDS  avgt    3  1.293 ± 0.212  us/op
Serialize.encodeReusing   100000  COMPOSITE_POISSON_EXTREME                0.01            FAST  NANOSECONDS  avgt    3  3.661 ± 0.521  us/op
Serialize.encodeReusing   100000            TRIMODAL_NORMAL                0.01            FAST  NANOSECONDS  avgt    3  2.236 ± 0.117  us/op
```

## After

```
Serialize.encode          100000                    POISSON                0.01            FAST  NANOSECONDS  avgt    3  2.879 ± 0.916  us/op
Serialize.encode          100000  COMPOSITE_POISSON_EXTREME                0.01            FAST  NANOSECONDS  avgt    3  6.311 ± 0.581  us/op
Serialize.encode          100000            TRIMODAL_NORMAL                0.01            FAST  NANOSECONDS  avgt    3  4.987 ± 1.020  us/op
Serialize.encodeReusing   100000                    POISSON                0.01            FAST  NANOSECONDS  avgt    3  2.277 ± 0.275  us/op
Serialize.encodeReusing   100000  COMPOSITE_POISSON_EXTREME                0.01            FAST  NANOSECONDS  avgt    3  5.304 ± 1.173  us/op
Serialize.encodeReusing   100000            TRIMODAL_NORMAL                0.01            FAST  NANOSECONDS  avgt    3  4.226 ± 0.443  us/op
```