### PR TITLE
Fix floating-point errors when encoding/decoding mappings

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -73,6 +73,8 @@ import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
  */
 public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
 
+  private static final double CORRECTING_FACTOR = 7 / (10 * Math.log(2));
+
   // Assuming we write the index as index(v) = floor(multiplier*ln(2)/ln(gamma)*(e+As^3+Bs^2+Cs)),
   // where v=2^e(1+s) and gamma = (1+relativeAccuracy)/(1-relativeAccuracy), those are the
   // coefficients that minimize the multiplier, therefore the memory footprint of the sketch, while
@@ -82,7 +84,7 @@ public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
   private static final double C = 10.0 / 7.0;
 
   public CubicallyInterpolatedMapping(double relativeAccuracy) {
-    super(relativeAccuracy);
+    super(gamma(requireValidRelativeAccuracy(relativeAccuracy), CORRECTING_FACTOR), 0);
   }
 
   /** {@inheritDoc} */
@@ -116,7 +118,7 @@ public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
 
   @Override
   double correctingFactor() {
-    return 7 / (10 * Math.log(2));
+    return CORRECTING_FACTOR;
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -73,8 +73,6 @@ import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
  */
 public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
 
-  private static final double CORRECTING_FACTOR = 7 / (10 * Math.log(2));
-
   // Assuming we write the index as index(v) = floor(multiplier*ln(2)/ln(gamma)*(e+As^3+Bs^2+Cs)),
   // where v=2^e(1+s) and gamma = (1+relativeAccuracy)/(1-relativeAccuracy), those are the
   // coefficients that minimize the multiplier, therefore the memory footprint of the sketch, while
@@ -82,6 +80,8 @@ public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
   private static final double A = 6.0 / 35.0;
   private static final double B = -3.0 / 5.0;
   private static final double C = 10.0 / 7.0;
+
+  private static final double CORRECTING_FACTOR = 1 / (C * Math.log(2));
 
   public CubicallyInterpolatedMapping(double relativeAccuracy) {
     super(gamma(requireValidRelativeAccuracy(relativeAccuracy), CORRECTING_FACTOR), 0);

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -23,21 +23,12 @@ import java.util.Objects;
  */
 abstract class LogLikeIndexMapping implements IndexMapping {
 
+  private final double gamma;
+  private final double indexOffset;
+
+  // Fields precomputed for performance.
   private final double relativeAccuracy;
   private final double multiplier;
-  private final double normalizedIndexOffset;
-
-  LogLikeIndexMapping(double relativeAccuracy) {
-    if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
-      throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
-    }
-    this.relativeAccuracy = relativeAccuracy;
-    this.multiplier =
-        correctingFactor()
-            * Math.log(base())
-            / (Math.log1p(2 * relativeAccuracy / (1 - relativeAccuracy)));
-    this.normalizedIndexOffset = 0;
-  }
 
   /**
    * Constructs a mapping that approximates x -> log(x) + indexOffset, where log is to the base
@@ -48,15 +39,31 @@ abstract class LogLikeIndexMapping implements IndexMapping {
    *     bound of the bucket of index 0
    */
   LogLikeIndexMapping(double gamma, double indexOffset) {
+    this.gamma = requireValidGamma(gamma);
+    this.indexOffset = indexOffset;
+    this.multiplier = Math.log(base()) / Math.log1p(gamma - 1);
+    this.relativeAccuracy = 1 - 2 / (1 + Math.exp(correctingFactor() * Math.log1p(gamma - 1)));
+  }
+
+  static double gamma(double relativeAccuracy, double correctingFactor) {
+    return Math.pow((1 + relativeAccuracy) / (1 - relativeAccuracy), 1 / correctingFactor);
+  }
+
+  static double requireValidRelativeAccuracy(double relativeAccuracy) {
+    if (relativeAccuracy <= 0 || relativeAccuracy >= 1) {
+      throw new IllegalArgumentException("The relative accuracy must be between 0 and 1.");
+    }
+    return relativeAccuracy;
+  }
+
+  private static double requireValidGamma(double gamma) {
     if (gamma <= 1) {
       throw new IllegalArgumentException("gamma must be greater than 1.");
     }
-    this.relativeAccuracy = 1 - 2 / (1 + Math.exp(correctingFactor() * Math.log1p(gamma - 1)));
-    this.multiplier = Math.log(base()) / Math.log1p(gamma - 1);
-    this.normalizedIndexOffset = indexOffset - log(1) * this.multiplier;
+    return gamma;
   }
 
-  /** @return an approximation of {@code log(1) + Math.log(value) / Math.log(base())} */
+  /** @return an approximation of {@code Math.log(value) / Math.log(base())} */
   abstract double log(double value);
 
   /**
@@ -78,7 +85,7 @@ abstract class LogLikeIndexMapping implements IndexMapping {
 
   @Override
   public final int index(double value) {
-    final double index = log(value) * multiplier + normalizedIndexOffset;
+    final double index = log(value) * multiplier + indexOffset;
     return index >= 0 ? (int) index : (int) index - 1; // faster than Math::floor
   }
 
@@ -89,7 +96,7 @@ abstract class LogLikeIndexMapping implements IndexMapping {
 
   @Override
   public double lowerBound(int index) {
-    return logInverse((index - normalizedIndexOffset) / multiplier);
+    return logInverse((index - indexOffset) / multiplier);
   }
 
   @Override
@@ -107,8 +114,7 @@ abstract class LogLikeIndexMapping implements IndexMapping {
     return Math.max(
         Math.pow(
             base(),
-            (Integer.MIN_VALUE - normalizedIndexOffset) / multiplier
-                - log(1)
+            (Integer.MIN_VALUE - indexOffset) / multiplier
                 + 1), // so that index >= Integer.MIN_VALUE
         Double.MIN_NORMAL * (1 + relativeAccuracy) / (1 - relativeAccuracy));
   }
@@ -118,8 +124,7 @@ abstract class LogLikeIndexMapping implements IndexMapping {
     return Math.min(
         Math.pow(
             base(),
-            (Integer.MAX_VALUE - normalizedIndexOffset) / multiplier
-                - log(1)
+            (Integer.MAX_VALUE - indexOffset) / multiplier
                 - 1), // so that index <= Integer.MAX_VALUE
         Double.MAX_VALUE / (1 + relativeAccuracy));
   }
@@ -133,13 +138,13 @@ abstract class LogLikeIndexMapping implements IndexMapping {
       return false;
     }
     final LogLikeIndexMapping that = (LogLikeIndexMapping) o;
-    return Double.compare(that.multiplier, multiplier) == 0
-        && Double.compare(that.normalizedIndexOffset, normalizedIndexOffset) == 0;
+    return Double.compare(that.gamma, gamma) == 0
+        && Double.compare(that.indexOffset, indexOffset) == 0;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(multiplier, normalizedIndexOffset);
+    return Objects.hash(gamma, indexOffset);
   }
 
   abstract IndexMappingLayout layout();
@@ -147,31 +152,31 @@ abstract class LogLikeIndexMapping implements IndexMapping {
   @Override
   public void encode(Output output) throws IOException {
     layout().toFlag().encode(output);
-    output.writeDoubleLE(gamma());
-    output.writeDoubleLE(indexOffset());
+    output.writeDoubleLE(gamma);
+    output.writeDoubleLE(indexOffset);
   }
 
   abstract Interpolation interpolation();
 
   @Override
   public int serializedSize() {
-    return doubleFieldSize(1, gamma())
-        + doubleFieldSize(2, indexOffset())
+    return doubleFieldSize(1, gamma)
+        + doubleFieldSize(2, indexOffset)
         + fieldSize(3, interpolation().ordinal());
   }
 
   @Override
   public void serialize(Serializer serializer) {
-    serializer.writeDouble(1, gamma());
-    serializer.writeDouble(2, indexOffset());
+    serializer.writeDouble(1, gamma);
+    serializer.writeDouble(2, indexOffset);
     serializer.writeUnsignedInt32(3, interpolation().ordinal());
   }
 
   double gamma() {
-    return Math.pow(base(), 1 / multiplier);
+    return gamma;
   }
 
   double indexOffset() {
-    return normalizedIndexOffset + log(1) * multiplier;
+    return indexOffset;
   }
 }

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -42,7 +42,12 @@ abstract class LogLikeIndexMapping implements IndexMapping {
     this.gamma = requireValidGamma(gamma);
     this.indexOffset = indexOffset;
     this.multiplier = Math.log(base()) / Math.log1p(gamma - 1);
-    this.relativeAccuracy = 1 - 2 / (1 + Math.exp(correctingFactor() * Math.log1p(gamma - 1)));
+    this.relativeAccuracy = relativeAccuracy(gamma, correctingFactor());
+  }
+
+  private static double relativeAccuracy(double gamma, double correctingFactor) {
+    double correctedGamma = Math.pow(gamma, correctingFactor);
+    return (correctedGamma - 1) / (correctedGamma + 1);
   }
 
   static double gamma(double relativeAccuracy, double correctingFactor) {

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMapping.java
@@ -45,13 +45,34 @@ abstract class LogLikeIndexMapping implements IndexMapping {
     this.relativeAccuracy = relativeAccuracy(gamma, correctingFactor());
   }
 
+  /**
+   * Calculates the relative accuracy of the mapping.
+   *
+   * @param gamma the base of the logarithm that the mapping approximates
+   * @param correctingFactor a measure of how well the mapping approximates the logarithm (see
+   *     {@link #correctingFactor()} for details)
+   * @return the relative accuracy of the mapping
+   */
   private static double relativeAccuracy(double gamma, double correctingFactor) {
-    double correctedGamma = Math.pow(gamma, correctingFactor);
-    return (correctedGamma - 1) / (correctedGamma + 1);
+    final double exactLogGamma = Math.pow(gamma, correctingFactor);
+    return (exactLogGamma - 1) / (exactLogGamma + 1);
   }
 
+  /**
+   * Calculates the (minimal) base that needs to be used for the mapping to be relatively accurate
+   * with the provided relative accuracy.
+   *
+   * @param relativeAccuracy the relative accuracy that we want the index mapping to guarantee
+   * @param correctingFactor a measure of how well the mapping approximates the logarithm (see
+   *     {@link #correctingFactor()} for details)
+   * @return the base of the logarithm to use to guarantee the provided relative accuracy
+   */
   static double gamma(double relativeAccuracy, double correctingFactor) {
-    return Math.pow((1 + relativeAccuracy) / (1 - relativeAccuracy), 1 / correctingFactor);
+    // exactLogGamma is the value of the base when using an exactly logarithmic mapping.
+    // When using a mapping that only approximates the logarithm, we need to adjust the base to
+    // correct for the induced loss of relative accuracy.
+    final double exactLogGamma = (1 + relativeAccuracy) / (1 - relativeAccuracy);
+    return Math.pow(exactLogGamma, 1 / correctingFactor);
   }
 
   static double requireValidRelativeAccuracy(double relativeAccuracy) {

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
@@ -17,7 +17,7 @@ import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
 public class LogarithmicMapping extends LogLikeIndexMapping {
 
   public LogarithmicMapping(double relativeAccuracy) {
-    super(relativeAccuracy);
+    super(gamma(requireValidRelativeAccuracy(relativeAccuracy), 1), 0);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
@@ -17,10 +17,11 @@ import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
  */
 public class QuadraticallyInterpolatedMapping extends LogLikeIndexMapping {
 
+  private static final double CORRECTING_FACTOR = 3 / (4 * Math.log(2));
   private static final double ONE_THIRD = 1.0 / 3.0;
 
   public QuadraticallyInterpolatedMapping(double relativeAccuracy) {
-    super(relativeAccuracy);
+    super(gamma(requireValidRelativeAccuracy(relativeAccuracy), CORRECTING_FACTOR), 0);
   }
 
   /** {@inheritDoc} */
@@ -50,7 +51,7 @@ public class QuadraticallyInterpolatedMapping extends LogLikeIndexMapping {
 
   @Override
   double correctingFactor() {
-    return 3 / (4 * Math.log(2));
+    return CORRECTING_FACTOR;
   }
 
   @Override

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
@@ -17,12 +17,12 @@ import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
  */
 public class QuarticallyInterpolatedMapping extends LogLikeIndexMapping {
 
-  private static final double CORRECTING_FACTOR = 25 / (36 * Math.log(2));
-
   private static final double A = -2.0 / 25.0;
   private static final double B = 8.0 / 25.0;
   private static final double C = -17.0 / 25.0;
   private static final double D = 36.0 / 25.0;
+
+  private static final double CORRECTING_FACTOR = 1 / (D * Math.log(2));
 
   public QuarticallyInterpolatedMapping(double relativeAccuracy) {
     super(gamma(requireValidRelativeAccuracy(relativeAccuracy), CORRECTING_FACTOR), 0);

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
@@ -17,13 +17,15 @@ import com.datadoghq.sketch.ddsketch.encoding.IndexMappingLayout;
  */
 public class QuarticallyInterpolatedMapping extends LogLikeIndexMapping {
 
+  private static final double CORRECTING_FACTOR = 25 / (36 * Math.log(2));
+
   private static final double A = -2.0 / 25.0;
   private static final double B = 8.0 / 25.0;
   private static final double C = -17.0 / 25.0;
   private static final double D = 36.0 / 25.0;
 
   public QuarticallyInterpolatedMapping(double relativeAccuracy) {
-    super(relativeAccuracy);
+    super(gamma(requireValidRelativeAccuracy(relativeAccuracy), CORRECTING_FACTOR), 0);
   }
 
   /** {@inheritDoc} */
@@ -68,7 +70,7 @@ public class QuarticallyInterpolatedMapping extends LogLikeIndexMapping {
 
   @Override
   double correctingFactor() {
-    return 25 / (36 * Math.log(2));
+    return CORRECTING_FACTOR;
   }
 
   @Override

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMappingTest.java
@@ -5,6 +5,10 @@
 
 package com.datadoghq.sketch.ddsketch.mapping;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
 class LinearlyInterpolatedMappingTest extends LogLikeIndexMappingTest {
 
   @Override
@@ -15,5 +19,13 @@ class LinearlyInterpolatedMappingTest extends LogLikeIndexMappingTest {
   @Override
   LinearlyInterpolatedMapping getMapping(double gamma, double indexOffset) {
     return new LinearlyInterpolatedMapping(gamma, indexOffset);
+  }
+
+  @Test
+  void testIndexOffset() {
+    // This is inconsistent with other mappings but this has to be maintained to ensure backward
+    // compatibility. Other mappings, when constructed from the relative accuracy, map 1 to 0.
+    assertThat(new LinearlyInterpolatedMapping(1e-1).index(1)).isEqualTo(4);
+    assertThat(new LinearlyInterpolatedMapping(1e-2).index(1)).isEqualTo(49);
   }
 }

--- a/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
+++ b/src/test/java/com/datadoghq/sketch/ddsketch/mapping/LogLikeIndexMappingTest.java
@@ -17,6 +17,7 @@ import com.datadoghq.sketch.ddsketch.encoding.Input;
 import com.datadoghq.sketch.util.accuracy.AccuracyTester;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 abstract class LogLikeIndexMappingTest extends IndexMappingTest {
@@ -71,7 +72,11 @@ abstract class LogLikeIndexMappingTest extends IndexMappingTest {
   @Test
   @Override
   void testEncodeDecode() {
-    final LogLikeIndexMapping mapping = getMapping(1.02, 3);
+    Stream.of(getMapping(1.02, 3), getMapping(0.01))
+        .forEach(LogLikeIndexMappingTest::testEncodeDecode);
+  }
+
+  private static void testEncodeDecode(LogLikeIndexMapping mapping) {
     final GrowingByteArrayOutput output = GrowingByteArrayOutput.withDefaultInitialCapacity();
     try {
       mapping.encode(output);


### PR DESCRIPTION
Similar to https://github.com/DataDog/sketches-go/pull/59, this change ensures that the serialized parameters of mappings (namely, `gamma` and `indexOffset`) are fields of the mapping classes, rather than being reconstructed from other fields (e.g., the relative accuracy).

Reconstructing `gamma` and `indexOffset` from other parameters may cause a mapping and the one built from encoding then decoding it to be different because of floating-point errors, which consequently triggers other issues when comparing sketches.