### PR TITLE
ddsketch: expose gamma ddsketch

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/BitwiseLinearlyInterpolatedMapping.java
@@ -35,7 +35,7 @@ public class BitwiseLinearlyInterpolatedMapping implements IndexMapping {
     this(getMinNumSignificantBinaryDigits(relativeAccuracy));
   }
 
-  BitwiseLinearlyInterpolatedMapping(int numSignificantBinaryDigits) {
+  public BitwiseLinearlyInterpolatedMapping(int numSignificantBinaryDigits) {
     if (numSignificantBinaryDigits < 0) {
       throw new IllegalArgumentException(
           "The number of significant binary digits cannot be negative.");

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/CubicallyInterpolatedMapping.java
@@ -88,7 +88,7 @@ public class CubicallyInterpolatedMapping extends LogLikeIndexMapping {
   }
 
   /** {@inheritDoc} */
-  CubicallyInterpolatedMapping(double gamma, double indexOffset) {
+  public CubicallyInterpolatedMapping(double gamma, double indexOffset) {
     super(gamma, indexOffset);
   }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LinearlyInterpolatedMapping.java
@@ -25,7 +25,7 @@ public class LinearlyInterpolatedMapping extends LogLikeIndexMapping {
   }
 
   /** {@inheritDoc} */
-  LinearlyInterpolatedMapping(double gamma, double indexOffset) {
+  public LinearlyInterpolatedMapping(double gamma, double indexOffset) {
     super(gamma, indexOffset);
   }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/LogarithmicMapping.java
@@ -21,7 +21,7 @@ public class LogarithmicMapping extends LogLikeIndexMapping {
   }
 
   /** {@inheritDoc} */
-  LogarithmicMapping(double gamma, double indexOffset) {
+  public LogarithmicMapping(double gamma, double indexOffset) {
     super(gamma, indexOffset);
   }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuadraticallyInterpolatedMapping.java
@@ -25,7 +25,7 @@ public class QuadraticallyInterpolatedMapping extends LogLikeIndexMapping {
   }
 
   /** {@inheritDoc} */
-  QuadraticallyInterpolatedMapping(double gamma, double indexOffset) {
+  public QuadraticallyInterpolatedMapping(double gamma, double indexOffset) {
     super(gamma, indexOffset);
   }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/mapping/QuarticallyInterpolatedMapping.java
@@ -29,7 +29,7 @@ public class QuarticallyInterpolatedMapping extends LogLikeIndexMapping {
   }
 
   /** {@inheritDoc} */
-  QuarticallyInterpolatedMapping(double gamma, double indexOffset) {
+  public QuarticallyInterpolatedMapping(double gamma, double indexOffset) {
     super(gamma, indexOffset);
   }
 


### PR DESCRIPTION
### What does this PR do?

Exposes the method to create the ddsketch with a specific gamma and index offset.

### Motivation

I want to use a specific index offset when creating the ddsketch. With the currently exposed methods, I can't do it.

### Additional Notes

Anything else we should know when reviewing?
