### PR TITLE
fix: Merge method fixed for collapsing methods

### DIFF
--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingHighestDenseStore.java
@@ -96,7 +96,7 @@ public class CollapsingHighestDenseStore extends CollapsingDenseStore {
     if (store instanceof CollapsingHighestDenseStore) {
       mergeWith((CollapsingHighestDenseStore) store);
     } else {
-      getAscendingStream().forEachOrdered(this::add);
+      store.getAscendingStream().forEachOrdered(this::add);
     }
   }
 

--- a/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStore.java
+++ b/src/main/java/com/datadoghq/sketch/ddsketch/store/CollapsingLowestDenseStore.java
@@ -96,7 +96,7 @@ public class CollapsingLowestDenseStore extends CollapsingDenseStore {
     if (store instanceof CollapsingLowestDenseStore) {
       mergeWith((CollapsingLowestDenseStore) store);
     } else {
-      getDescendingStream().forEachOrdered(this::add);
+      store.getDescendingStream().forEachOrdered(this::add);
     }
   }
 


### PR DESCRIPTION
Merging collapsingDense stores causes collapsingDense store to just double itself